### PR TITLE
Fix crash risks, race conditions, and silent failures

### DIFF
--- a/Shared/Configuration/CronicaApp.swift
+++ b/Shared/Configuration/CronicaApp.swift
@@ -228,23 +228,19 @@ struct CronicaApp: App {
     private func handleAppRefresh(task: BGAppRefreshTask?) {
         if let task {
             scheduleAppRefresh()
-            let queue = OperationQueue()
-            queue.maxConcurrentOperationCount = 1
+            let workItem = Task {
+                await BackgroundManager.shared.handleWatchingContentRefresh()
+                BackgroundManager.shared.lastWatchingRefresh = Date()
+                await BackgroundManager.shared.handleUpcomingContentRefresh()
+                BackgroundManager.shared.lastUpcomingRefresh = Date()
+                await BackgroundManager.shared.handleAppRefreshMaintenance()
+                BackgroundManager.shared.lastMaintenance = Date()
+                task.setTaskCompleted(success: true)
+            }
             task.expirationHandler = {
-                // After all operations are cancelled, the completion block below is called to set the task to complete.
-                queue.cancelAllOperations()
+                workItem.cancel()
+                task.setTaskCompleted(success: false)
             }
-            queue.addOperation {
-                Task {
-                    await BackgroundManager.shared.handleWatchingContentRefresh()
-                    BackgroundManager.shared.lastWatchingRefresh = Date()
-                    await BackgroundManager.shared.handleUpcomingContentRefresh()
-                    BackgroundManager.shared.lastUpcomingRefresh = Date()
-                    await BackgroundManager.shared.handleAppRefreshMaintenance()
-                    BackgroundManager.shared.lastMaintenance = Date()
-                }
-            }
-            task.setTaskCompleted(success: true)
         }
     }
 #elseif os(macOS)

--- a/Shared/Controllers/PersistenceController.swift
+++ b/Shared/Controllers/PersistenceController.swift
@@ -7,10 +7,15 @@
 
 import CoreData
 import CloudKit
+import os
 
 /// An environment singleton responsible for managing Watchlist Core Data stack, including handling saving,
 /// tracking watchlists, and dealing with sample data.
 struct PersistenceController {
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.cronica",
+        category: "PersistenceController"
+    )
     static let shared = PersistenceController()
     // MARK: Preview sample
     static var preview: PersistenceController = {
@@ -64,7 +69,11 @@ struct PersistenceController {
     
     func save() {
         if container.viewContext.hasChanges {
-            try? container.viewContext.save()
+            do {
+                try container.viewContext.save()
+            } catch {
+                Self.logger.error("Core Data save failed: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/Shared/Extensions/ItemContent-Extensions.swift
+++ b/Shared/Extensions/ItemContent-Extensions.swift
@@ -101,8 +101,8 @@ extension ItemContent {
         return nil
     }
     var itemInfo: String {
-        if itemTheatricalString != nil && shortItemRuntime != nil {
-            return "\(itemGenre) • \(itemTheatricalString!) • \(shortItemRuntime!)"
+        if let theatricalString = itemTheatricalString, let runtime = shortItemRuntime {
+            return "\(itemGenre) • \(theatricalString) • \(runtime)"
         }
         if let itemTheatricalString {
             return "\(itemGenres) • \(itemTheatricalString)"
@@ -123,8 +123,8 @@ extension ItemContent {
         return ""
     }
     var itemQuickInfo: String {
-        if itemTheatricalString != nil && shortItemRuntime != nil {
-            return "\(itemTheatricalString!) • \(shortItemRuntime!)"
+        if let theatricalString = itemTheatricalString, let runtime = shortItemRuntime {
+            return "\(theatricalString) • \(runtime)"
         }
         if let itemTheatricalString {
             return "\(itemTheatricalString)"
@@ -245,7 +245,10 @@ extension ItemContent {
 #endif
     }
     var itemURL: URL {
-        return URL(string: "https://www.themoviedb.org/\(itemContentMedia.rawValue)/\(id)")!
+        guard let url = URL(string: "https://www.themoviedb.org/\(itemContentMedia.rawValue)/\(id)") else {
+            return URL(string: "https://www.themoviedb.org")!
+        }
+        return url
     }
     
     // MARK: Bool
@@ -279,11 +282,8 @@ extension ItemContent {
         if media == .person {
             return media.title
         }
-        if itemTheatricalString != nil && shortItemRuntime != nil {
-            return "\(itemContentMedia.title) • \(itemTheatricalString!)"
-        }
-        if let itemTheatricalString {
-            return "\(itemContentMedia.title) • \(itemTheatricalString)"
+        if let theatricalString = itemTheatricalString {
+            return "\(itemContentMedia.title) • \(theatricalString)"
         }
         if let date = nextEpisodeDate {
             return "\(itemContentMedia.title) • \(DatesManager.dateString.string(from: date))"
@@ -304,8 +304,8 @@ extension ItemContent {
     }
 	var itemNotificationDescription: String {
 		if itemContentMedia == .movie {
-			if itemTheatricalString != nil && shortItemRuntime != nil {
-				return "\(itemContentMedia.title) • \(itemTheatricalString!)"
+			if let theatricalString = itemTheatricalString {
+				return "\(itemContentMedia.title) • \(theatricalString)"
 			}
 			if let itemTheatricalString {
 				return "\(itemContentMedia.title) • \(itemTheatricalString)"
@@ -401,7 +401,7 @@ extension ItemContent {
     // MARK: Preview
     static var examples: [ItemContent] {
         let data: ItemContentResponse? = try? Bundle.main.decode(from: "content")
-        return data!.results
+        return data?.results ?? []
     }
     static var example: ItemContent {
         examples[0]

--- a/Shared/Extensions/WatchlistItem-Extension.swift
+++ b/Shared/Extensions/WatchlistItem-Extension.swift
@@ -57,7 +57,10 @@ extension WatchlistItem {
 		}
 	}
 	var itemLink: URL {
-		return URL(string: "https://www.themoviedb.org/\(itemMedia.rawValue)/\(itemId)")!
+		guard let url = URL(string: "https://www.themoviedb.org/\(itemMedia.rawValue)/\(itemId)") else {
+			return URL(string: "https://www.themoviedb.org")!
+		}
+		return url
 	}
 	var itemDateForNextSeason: String {
 		guard let date else { return String() }

--- a/Shared/Helpers/KeychainHelper.swift
+++ b/Shared/Helpers/KeychainHelper.swift
@@ -19,8 +19,22 @@ final class KeychainHelper {
             kSecAttrService: service,
             kSecAttrAccount: account,
         ] as [CFString : Any] as CFDictionary
-        
-        _ = SecItemAdd(query, nil)
+
+        let status = SecItemAdd(query, nil)
+
+        if status == errSecDuplicateItem {
+            let searchQuery = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: service,
+                kSecAttrAccount: account,
+            ] as [CFString : Any] as CFDictionary
+
+            let attributesToUpdate = [
+                kSecValueData: data
+            ] as [CFString : Any] as CFDictionary
+
+            SecItemUpdate(searchQuery, attributesToUpdate)
+        }
     }
     
     func read(service: String, account: String) -> Data? {

--- a/Shared/Manager/AccountManager.swift
+++ b/Shared/Manager/AccountManager.swift
@@ -144,7 +144,8 @@ class AccountManager: ObservableObject {
         do {
             let parameters = ["session_id": "\(self.userSessionId)"]
             let postData = try JSONSerialization.data(withJSONObject: parameters)
-            var request = URLRequest(url: URL(string: "https://api.themoviedb.org/3/authentication/session?api_key=\(Key.tmdbApi)")!,
+            guard let deleteUrl = URL(string: "https://api.themoviedb.org/3/authentication/session?api_key=\(Key.tmdbApi)") else { return }
+            var request = URLRequest(url: deleteUrl,
                                      cachePolicy: .useProtocolCachePolicy,
                                      timeoutInterval: 10.0)
             request.httpMethod = "DELETE"

--- a/Shared/Manager/ExternalWatchlistManager.swift
+++ b/Shared/Manager/ExternalWatchlistManager.swift
@@ -56,7 +56,8 @@ class ExternalWatchlistManager: ObservableObject {
                 "content-type": contentTypeHeader,
                 "authorization": "Bearer \(userAccessToken)"
             ]
-            var request = URLRequest(url: URL(string: "https://api.themoviedb.org/4/account/\(userAccessId)/\(type.rawValue)/watchlist?page=\(page)&sort_by=created_at.asc")!,
+            guard let watchlistUrl = URL(string: "https://api.themoviedb.org/4/account/\(userAccessId)/\(type.rawValue)/watchlist?page=\(page)&sort_by=created_at.asc") else { return nil }
+            var request = URLRequest(url: watchlistUrl,
                                      cachePolicy: .useProtocolCachePolicy,
                                      timeoutInterval: 10.0)
             request.httpMethod = "GET"

--- a/Shared/Manager/NotificationManager.swift
+++ b/Shared/Manager/NotificationManager.swift
@@ -28,12 +28,9 @@ class NotificationManager: ObservableObject {
         }
     }
     
-    func isNotificationAllowed() -> Bool {
-        var isAllowed = false
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            if settings.authorizationStatus == .authorized { isAllowed.toggle() }
-        }
-        return isAllowed
+    func isNotificationAllowed() async -> Bool {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        return settings.authorizationStatus == .authorized
     }
     
     func schedule(_ content: ItemContent) {
@@ -197,7 +194,8 @@ class NotificationManager: ObservableObject {
             }
             let id = identifier.dropLast(2)
             do {
-                let item = try await service.fetchItem(id: Int(id)!, type: media)
+                guard let contentID = Int(id) else { continue }
+                let item = try await service.fetchItem(id: contentID, type: media)
                 items.append(item)
             } catch {
                 return nil

--- a/Shared/View/Buttons/WatchlistButton.swift
+++ b/Shared/View/Buttons/WatchlistButton.swift
@@ -57,7 +57,8 @@ struct WatchlistButton: View {
                 media = .tvShow
             }
             let contentID = identifier.dropLast(2)
-            let content = try? await NetworkService.shared.fetchItem(id: Int(contentID)!, type: media)
+            guard let contentIDNumber = Int(contentID) else { return }
+            let content = try? await NetworkService.shared.fetchItem(id: contentIDNumber, type: media)
             guard let content else { return }
             persistence.save(content)
             registerNotification(content)


### PR DESCRIPTION
## Summary
- **Force unwraps removed**: Replace `URL(string:)!` and `Int()!` force unwraps with safe unwrapping in 6 files to prevent runtime crashes
- **Race condition fixed**: `NotificationManager.isNotificationAllowed()` was returning synchronously before its async callback completed (always returned `false`) — now uses `async/await`
- **BGTask completion fixed**: `task.setTaskCompleted(success: true)` was called immediately before background work finished — now only completes after all refresh tasks are done
- **Keychain duplicate handling**: `KeychainHelper.save()` silently failed on duplicate items — now falls back to `SecItemUpdate` on `errSecDuplicateItem`
- **Core Data error logging**: `PersistenceController.save()` silently swallowed save errors — now logs failures via `os.Logger`

## Files changed (9)
- `CronicaApp.swift` — BGTask completion timing
- `PersistenceController.swift` — Error logging for save()
- `ItemContent-Extensions.swift` — 8 force unwraps replaced
- `WatchlistItem-Extension.swift` — 1 force unwrap replaced
- `KeychainHelper.swift` — Duplicate item handling
- `AccountManager.swift` — 1 force unwrap replaced
- `ExternalWatchlistManager.swift` — 1 force unwrap replaced
- `NotificationManager.swift` — Race condition fix + 1 force unwrap
- `WatchlistButton.swift` — 1 force unwrap replaced

## Test plan
- [ ] Verify app builds and runs on iOS simulator
- [ ] Test adding/removing items from watchlist (exercises KeychainHelper, PersistenceController, WatchlistButton)
- [ ] Test notification scheduling for upcoming content
- [ ] Verify background refresh completes properly (can monitor via Console.app logs)
- [ ] Confirm Core Data save errors now appear in Console.app logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)