### PR TITLE
Polish redesign: immersive chrome, motion, and a11y

### DIFF
--- a/Shared/Localization/Localizable.xcstrings
+++ b/Shared/Localization/Localizable.xcstrings
@@ -1,6 +1,28 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "We couldn\u2019t finish this search. Check your connection and try again." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We couldn\u2019t finish this search. Check your connection and try again."
+          }
+        }
+      }
+    },
+    "Mark titles as watched to unlock a personal For You shelf." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark titles as watched to unlock a personal For You shelf."
+          }
+        }
+      }
+    },
     "Translucent artwork behind details helps set a cinematic mood. Disable it for a flatter look." : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Shared/View/Components/CronicaDesign.swift
+++ b/Shared/View/Components/CronicaDesign.swift
@@ -33,7 +33,7 @@ enum CronicaDesign {
 
     enum Typography {
         static func brand() -> Font {
-#if os(tvOS)
+#if os(watchOS) || os(tvOS)
             return .largeTitle.weight(.bold)
 #else
             return .system(.largeTitle, design: .serif).weight(.bold)
@@ -41,7 +41,7 @@ enum CronicaDesign {
         }
 
         static func display() -> Font {
-#if os(tvOS)
+#if os(watchOS) || os(tvOS)
             return .title2.weight(.semibold)
 #else
             return .system(.title2, design: .serif).weight(.semibold)
@@ -49,8 +49,8 @@ enum CronicaDesign {
         }
 
         static func sectionTitle() -> Font {
-#if os(tvOS)
-            return .callout.weight(.semibold)
+#if os(watchOS) || os(tvOS)
+            return .headline.weight(.semibold)
 #else
             return .system(.title3, design: .serif).weight(.semibold)
 #endif

--- a/Shared/View/Components/HomeBrandHeader.swift
+++ b/Shared/View/Components/HomeBrandHeader.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import NukeUI
 
+#if os(iOS)
 struct HomeBrandHeader: View {
     var featuredImage: URL?
     var featuredTitle: String?
@@ -120,3 +121,4 @@ struct HomeBrandHeader: View {
     HomeBrandHeader(featuredImage: ItemContent.example.cardImageLarge,
                     featuredTitle: ItemContent.example.itemTitle)
 }
+#endif

--- a/Shared/View/Components/TranslucentBackground.swift
+++ b/Shared/View/Components/TranslucentBackground.swift
@@ -13,8 +13,9 @@ struct TranslucentBackground: View {
     var image: URL?
     @AppStorage("disableTranslucentBackground") private var disableTranslucent = false
     var useLighterMaterial = false
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     var body: some View {
-        if !disableTranslucent && image != nil {
+        if !disableTranslucent && !reduceTransparency && image != nil {
             ZStack {
                 LazyImage(url: image) { state in
                     if let image = state.image {

--- a/Shared/View/ItemContent/ItemContentDetails.swift
+++ b/Shared/View/ItemContent/ItemContentDetails.swift
@@ -45,6 +45,8 @@ struct ItemContentDetails: View {
     
     // MARK: Animation properties
     @State private var animateFavorite = false
+    @State private var heroAppeared = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     var body: some View {
         ScrollView {
             VStack {
@@ -195,12 +197,14 @@ struct ItemContentDetails: View {
         }
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
         .actionPopup(isShowing: $showPopup, for: popupType)
     }
 
     private var cinematicHero: some View {
         ZStack(alignment: .bottomLeading) {
             cover
+                .scaleEffect(heroAppeared || reduceMotion ? 1 : 1.06)
             CronicaDesign.Atmosphere.gradient
                 .allowsHitTesting(false)
             VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
@@ -209,10 +213,21 @@ struct ItemContentDetails: View {
             }
             .padding(.horizontal, CronicaDesign.Spacing.lg)
             .padding(.bottom, CronicaDesign.Spacing.lg)
+            .opacity(heroAppeared ? 1 : 0)
+            .offset(y: heroAppeared || reduceMotion ? 0 : 16)
         }
         .frame(height: CronicaDesign.Atmosphere.detailHeroHeight)
         .frame(maxWidth: .infinity)
         .clipped()
+        .onAppear {
+            if reduceMotion {
+                heroAppeared = true
+            } else {
+                withAnimation(CronicaDesign.Motion.hero) {
+                    heroAppeared = true
+                }
+            }
+        }
     }
 
     @ViewBuilder

--- a/Shared/View/Navigation/ExploreView.swift
+++ b/Shared/View/Navigation/ExploreView.swift
@@ -82,15 +82,17 @@ struct ExploreView: View {
                 } else if !isLoadingRecommendations, recommendations.isEmpty {
                     ContentUnavailableView {
                         Label("Start watching to get recommendations...",
-                              systemImage: "popcorn")
+                              systemImage: "popcorn.fill")
                     } description: {
-                        Text("Watch more titles to receive recommendations.")
+                        Text("Mark titles as watched to unlock a personal For You shelf.")
                     } actions: {
                         Button("Discover Movies & TV Shows") {
                             selectedForYouTab = .explore
                         }
                         .buttonStyle(.borderedProminent)
+                        .tint(settings.appTheme.color)
                     }
+                    .padding(.horizontal, CronicaDesign.Spacing.lg)
                     .unredacted()
                 } else {
                     switch settings.sectionStyleType {
@@ -227,6 +229,7 @@ struct ExploreView: View {
 #endif
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.automatic, for: .navigationBar)
 #endif
         .onChange(of: hideAddedItems) { _, value in
             if value {

--- a/Shared/View/Navigation/HomeView.swift
+++ b/Shared/View/Navigation/HomeView.swift
@@ -161,6 +161,7 @@ struct HomeView: View {
         .navigationTitle("Home")
 #if os(iOS)
         .navigationBarTitleDisplayMode(UIDevice.isIPhone ? .inline : .large)
+        .toolbarBackground(UIDevice.isIPhone ? .hidden : .automatic, for: .navigationBar)
 #endif
 #endif
         .toolbar {

--- a/Shared/View/Navigation/SearchView.swift
+++ b/Shared/View/Navigation/SearchView.swift
@@ -38,6 +38,7 @@ struct SearchView: View {
 #endif
 #if os(iOS)
         .navigationBarTitleDisplayMode(.large)
+        .toolbarBackground(.automatic, for: .navigationBar)
 #endif
         .navigationDestination(for: Person.self) { person in
             PersonDetailsView(name: person.name, id: person.id)
@@ -217,17 +218,23 @@ struct SearchView: View {
     @ViewBuilder
     private var emptyView: some View {
         ContentUnavailableView.search(text: viewModel.query)
+            .padding(.horizontal, CronicaDesign.Spacing.md)
     }
     
     private var searchingView: some View {
         ProgressView("Searching")
-            .foregroundColor(.secondary)
-            .padding()
+            .foregroundStyle(.secondary)
+            .padding(CronicaDesign.Spacing.lg)
     }
     
     @ViewBuilder
     private var failureView: some View {
-        ContentUnavailableView("Try again later", systemImage: "magnifyingglass").padding()
+        ContentUnavailableView {
+            Label("Try again later", systemImage: "wifi.exclamationmark")
+        } description: {
+            Text("We couldn’t finish this search. Check your connection and try again.")
+        }
+        .padding(CronicaDesign.Spacing.md)
     }
     
     @ViewBuilder

--- a/Shared/View/Navigation/WatchlistView.swift
+++ b/Shared/View/Navigation/WatchlistView.swift
@@ -46,6 +46,7 @@ struct WatchlistView: View {
         }
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.automatic, for: .navigationBar)
 #elseif os(tvOS)
         .ignoresSafeArea(.all, edges: .horizontal)
 #endif

--- a/Shared/View/Search/SearchItem.swift
+++ b/Shared/View/Search/SearchItem.swift
@@ -35,25 +35,19 @@ struct SearchItem: View {
                     .hoverEffect()
 #endif
             }
-            VStack(alignment: .leading) {
-                HStack {
-                    Text(item.itemTitle)
-                        .lineLimit(DrawingConstants.textLimit)
-                }
+            VStack(alignment: .leading, spacing: CronicaDesign.Spacing.xxs) {
+                Text(item.itemTitle)
+                    .font(CronicaDesign.Typography.body())
+                    .fontWeight(.medium)
+                    .lineLimit(DrawingConstants.textLimit)
 #if os(watchOS)
-                HStack {
-                    Text(item.media.title)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                }
+                Text(item.media.title)
+                    .font(CronicaDesign.Typography.caption())
+                    .foregroundStyle(.secondary)
 #else
-                HStack {
-                    Text(item.itemSearchDescription)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                }
+                Text(item.itemSearchDescription)
+                    .font(CronicaDesign.Typography.caption())
+                    .foregroundStyle(.secondary)
 #endif
             }
         }

--- a/Shared/View/Up Next/HorizontalUpNextListView.swift
+++ b/Shared/View/Up Next/HorizontalUpNextListView.swift
@@ -73,8 +73,13 @@ struct HorizontalUpNextListView: View {
                                             .environmentObject(viewModel)
                                             .frame(width: settings.isCompactUI ? DrawingConstants.compactImageWidth : DrawingConstants.imageWidth,
                                                    height: settings.isCompactUI ? DrawingConstants.compactImageHeight : DrawingConstants.imageHeight)
-                                            .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
-                                            .shadow(color: .black.opacity(0.2), radius: 6, x: 0, y: 5)
+                                            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
+                                            .shadow(
+                                                color: .black.opacity(CronicaDesign.Shadow.mediaOpacity),
+                                                radius: CronicaDesign.Shadow.mediaRadius,
+                                                x: 0,
+                                                y: CronicaDesign.Shadow.mediaY
+                                            )
                                             .accessibilityLabel("Episode: \(item.episode.itemEpisodeNumber), of the show: \(item.showTitle).")
                                             .accessibilityAddTraits(.isButton)
                                             .applyHoverEffect()
@@ -244,15 +249,19 @@ private struct UpNextCard: View {
                             }
                             .frame(width: settings.isCompactUI ? DrawingConstants.compactImageWidth : DrawingConstants.imageWidth,
                                    height: settings.isCompactUI ? DrawingConstants.compactImageHeight : DrawingConstants.imageHeight)
-                            .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
+                            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
                         }
                     }
                     .transition(.opacity)
                     .frame(width: settings.isCompactUI ? DrawingConstants.compactImageWidth : DrawingConstants.imageWidth,
                            height: settings.isCompactUI ? DrawingConstants.compactImageHeight : DrawingConstants.imageHeight)
-                    .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius,
-                                                style: .continuous))
-                    .shadow(color: .black.opacity(0.2), radius: 5, x: 0, y: 5)
+                    .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
+                    .shadow(
+                        color: .black.opacity(CronicaDesign.Shadow.mediaOpacity),
+                        radius: CronicaDesign.Shadow.mediaRadius,
+                        x: 0,
+                        y: CronicaDesign.Shadow.mediaY
+                    )
                     .applyHoverEffect()
 #if !os(tvOS)
                     if !settings.isCompactUI {
@@ -378,7 +387,6 @@ private struct DrawingConstants {
 #endif
     static let compactImageWidth: CGFloat = 160
     static let compactImageHeight: CGFloat = 100
-    static let imageRadius: CGFloat = 12
-    static let titleLineLimit: Int = 1
+        static let titleLineLimit: Int = 1
     static let imageShadow: CGFloat = 2.5
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to the merged cinematic redesign (#51). Tightens Liquid Glass-friendly chrome, adds detail hero motion, deepens Discover/Search/Up Next polish, and hardens Reduce Motion / Reduce Transparency behavior.

## Changes
- Hide nav bar background over Home and Details heroes so artwork leads
- Animate detail cover entrance (skipped when Reduce Motion is on)
- Align Up Next media chrome with `CronicaDesign` radii/shadows
- Refresh Discover For You empty state and Search failure/empty presentation
- Skip translucent backgrounds when Reduce Transparency is enabled
- Scope `HomeBrandHeader` to iOS; soften watchOS typography tokens

## Test plan
- [ ] Home iPhone: hero sits under a clear nav bar; sections still navigate
- [ ] Details: cover fades/scales in; with Reduce Motion, appears immediately
- [ ] Settings → Accessibility Reduce Transparency: detail atmosphere disabled
- [ ] Discover For You empty state CTA uses accent tint
- [ ] Search failure state copy/layout looks correct
- [ ] Watch/tvOS/macOS still compile with shared token changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

