### PR TITLE
Cinematic redesign pass for iPad, Mac, and tvOS

### DIFF
--- a/Shared/Enums/Screens/Screens.swift
+++ b/Shared/Enums/Screens/Screens.swift
@@ -17,7 +17,7 @@ enum Screens: String, Identifiable, CaseIterable {
     var title: String {
         switch self {
         case .home: NSLocalizedString("Home", comment: "")
-        case .explore: NSLocalizedString("Explore", comment: "")
+        case .explore: NSLocalizedString("Discover", comment: "")
         case .watchlist: NSLocalizedString("Watchlist", comment: "")
         case .search: NSLocalizedString("Search", comment: "")
 #if os(iOS) || os(tvOS) || os(visionOS)

--- a/Shared/View/Components/CronicaDesign.swift
+++ b/Shared/View/Components/CronicaDesign.swift
@@ -58,7 +58,7 @@ enum CronicaDesign {
 
         static func sectionSubtitle() -> Font {
 #if os(tvOS)
-            return .caption
+            return .title3
 #else
             return .subheadline
 #endif
@@ -85,8 +85,42 @@ enum CronicaDesign {
 
     enum Atmosphere {
         static let heroHeightPhone: CGFloat = 420
+        static let heroHeightPad: CGFloat = 520
+        static let heroHeightMac: CGFloat = 380
+        static let heroHeightTV: CGFloat = 560
         static let heroHeightCompact: CGFloat = 320
-        static let detailHeroHeight: CGFloat = 460
+        static let detailHeroHeightPhone: CGFloat = 460
+        static let detailHeroHeightPad: CGFloat = 520
+        static let detailHeroHeightMac: CGFloat = 420
+        static let detailHeroHeightTV: CGFloat = 540
+
+        /// Back-compat alias used by phone details.
+        static let detailHeroHeight: CGFloat = detailHeroHeightPhone
+
+        static var homeHeroHeight: CGFloat {
+#if os(tvOS)
+            return heroHeightTV
+#elseif os(macOS)
+            return heroHeightMac
+#elseif os(iOS)
+            return UIDevice.isIPad ? heroHeightPad : heroHeightPhone
+#else
+            return heroHeightPhone
+#endif
+        }
+
+        static var detailHeroHeightForPlatform: CGFloat {
+#if os(tvOS)
+            return detailHeroHeightTV
+#elseif os(macOS)
+            return detailHeroHeightMac
+#elseif os(iOS)
+            return UIDevice.isIPad ? detailHeroHeightPad : detailHeroHeightPhone
+#else
+            return detailHeroHeightPhone
+#endif
+        }
+
         static let gradient = LinearGradient(
             colors: [
                 .black.opacity(0.05),
@@ -112,9 +146,16 @@ extension View {
     }
 
     func cronicaGlassSurface() -> some View {
+#if os(tvOS)
+        self.background(
+            .regularMaterial,
+            in: RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous)
+        )
+#else
         self.background(
             .ultraThinMaterial,
             in: RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous)
         )
+#endif
     }
 }

--- a/Shared/View/Components/HomeBrandHeader.swift
+++ b/Shared/View/Components/HomeBrandHeader.swift
@@ -8,10 +8,12 @@
 import SwiftUI
 import NukeUI
 
-#if os(iOS)
+#if !os(watchOS)
 struct HomeBrandHeader: View {
     var featuredImage: URL?
     var featuredTitle: String?
+    var height: CGFloat = CronicaDesign.Atmosphere.homeHeroHeight
+    var compactCopy = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appeared = false
     @StateObject private var store = SettingsStore.shared
@@ -22,12 +24,15 @@ struct HomeBrandHeader: View {
             CronicaDesign.Atmosphere.gradient
                 .allowsHitTesting(false)
             copyBlock
-                .padding(.horizontal, CronicaDesign.Spacing.lg)
+                .padding(.horizontal, horizontalPadding)
                 .padding(.bottom, CronicaDesign.Spacing.lg)
         }
-        .frame(height: CronicaDesign.Atmosphere.heroHeightPhone)
+        .frame(height: height)
         .frame(maxWidth: .infinity)
         .clipped()
+#if os(tvOS)
+        .focusable(false)
+#endif
         .onAppear {
             if reduceMotion {
                 appeared = true
@@ -37,6 +42,14 @@ struct HomeBrandHeader: View {
                 }
             }
         }
+    }
+
+    private var horizontalPadding: CGFloat {
+#if os(tvOS)
+        return 64
+#else
+        return CronicaDesign.Spacing.lg
+#endif
     }
 
     @ViewBuilder
@@ -70,7 +83,7 @@ struct HomeBrandHeader: View {
                 endPoint: .bottomTrailing
             )
             Image(systemName: "popcorn.fill")
-                .font(.system(size: 72, weight: .semibold))
+                .font(.system(size: compactCopy ? 56 : 72, weight: .semibold))
                 .foregroundStyle(.white.opacity(0.12))
                 .offset(x: 80, y: -40)
         }
@@ -88,15 +101,17 @@ struct HomeBrandHeader: View {
             Text(headline)
                 .font(CronicaDesign.Typography.display())
                 .foregroundStyle(.white)
-                .lineLimit(2)
+                .lineLimit(compactCopy ? 1 : 2)
                 .opacity(appeared ? 1 : 0)
                 .offset(y: appeared ? 0 : 12)
 
-            Text(supporting)
-                .font(CronicaDesign.Typography.sectionSubtitle())
-                .foregroundStyle(.white.opacity(0.82))
-                .lineLimit(2)
-                .opacity(appeared ? 1 : 0)
+            if !compactCopy {
+                Text(supporting)
+                    .font(CronicaDesign.Typography.sectionSubtitle())
+                    .foregroundStyle(.white.opacity(0.82))
+                    .lineLimit(2)
+                    .opacity(appeared ? 1 : 0)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)

--- a/Shared/View/ItemContent/ItemContentDetails.swift
+++ b/Shared/View/ItemContent/ItemContentDetails.swift
@@ -151,9 +151,9 @@ struct ItemContentDetails: View {
         VStack(spacing: 0) {
             if store.usePostersAsCover || viewModel.showPoster {
                 poster
-                phoneTitleBlock(alignment: .center, light: false)
+                detailTitleBlock(alignment: .center, light: false)
                     .padding(.top, CronicaDesign.Spacing.sm)
-                phoneActionCluster
+                detailActionCluster
                     .padding(.top, CronicaDesign.Spacing.md)
             } else {
                 cinematicHero
@@ -208,15 +208,15 @@ struct ItemContentDetails: View {
             CronicaDesign.Atmosphere.gradient
                 .allowsHitTesting(false)
             VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
-                phoneTitleBlock(alignment: .leading, light: true)
-                phoneActionCluster
+                detailTitleBlock(alignment: .leading, light: true)
+                detailActionCluster
             }
             .padding(.horizontal, CronicaDesign.Spacing.lg)
             .padding(.bottom, CronicaDesign.Spacing.lg)
             .opacity(heroAppeared ? 1 : 0)
             .offset(y: heroAppeared || reduceMotion ? 0 : 16)
         }
-        .frame(height: CronicaDesign.Atmosphere.detailHeroHeight)
+        .frame(height: CronicaDesign.Atmosphere.detailHeroHeightForPlatform)
         .frame(maxWidth: .infinity)
         .clipped()
         .onAppear {
@@ -229,9 +229,11 @@ struct ItemContentDetails: View {
             }
         }
     }
-
+#endif
+    
+#if !os(tvOS)
     @ViewBuilder
-    private func phoneTitleBlock(alignment: HorizontalAlignment, light: Bool) -> some View {
+    private func detailTitleBlock(alignment: HorizontalAlignment, light: Bool) -> some View {
         VStack(alignment: alignment, spacing: CronicaDesign.Spacing.xxs) {
             Text(title)
                 .multilineTextAlignment(alignment == .leading ? .leading : .center)
@@ -254,7 +256,7 @@ struct ItemContentDetails: View {
         }
     }
 
-    private var phoneActionCluster: some View {
+    private var detailActionCluster: some View {
         HStack(spacing: CronicaDesign.Spacing.sm) {
             if type == .movie {
                 watchButton
@@ -270,83 +272,42 @@ struct ItemContentDetails: View {
         .cronicaGlassSurface()
         .padding(.horizontal, CronicaDesign.Spacing.md)
     }
-#endif
-    
-#if !os(tvOS)
-    private var sizeBasedPadMacView: some View {
-        VStack {
-            
-            // Header
-            HStack {
-                poster
-                
-                VStack(alignment: .leading) {
-                    Text(title)
-                        .fontWeight(.semibold)
-                        .font(.title)
-                        .padding(.bottom)
-                    HStack {
-                        Text(viewModel.content?.itemOverview ?? "")
-                            .lineLimit(10)
-                            .onTapGesture {
-                                showOverview.toggle()
-                            }
-                        Spacer()
-                    }
-                    .frame(maxWidth: 460)
-                    .padding(.bottom)
-                    .popover(isPresented: $showOverview) {
-                        if let overview = viewModel.content?.itemOverview {
-                            VStack {
-                                ScrollView {
-                                    Text(overview)
-                                        .padding()
-                                }
-                            }
-                            .frame(minWidth: 200, maxWidth: 400, minHeight: 200, maxHeight: 300, alignment: .center)
-                        }
-                    }
-                    
-                    // Actions
-                    HStack {
-                        watchlistButton
-                            .padding(.trailing)
-                        
-                        if viewModel.isInWatchlist {
-                            if type == .movie {
-                                watchButton
-                            } else {
-                                favoriteButton
-                            }
-                            
-                            listButton
-                                .padding(.horizontal)
-                        }
-                    }
-                }
-                .frame(width: 360)
-                
-                ViewThatFits {
-                    quickInformationBoxView
-                        .frame(width: 280)
-                        .padding(.horizontal)
-                        .onAppear {
-                            showInfoBox = false
-                            isSideInfoPanelShowed = true
-                        }
-                        .onDisappear {
-                            showInfoBox = true
-                            isSideInfoPanelShowed = false
-                        }
-                    VStack {
-                        Text("")
-                    }
-                }
-                
-                Spacer()
+
+    private var cover: some View {
+        HeroImage(url: viewModel.content?.cardImageLarge,
+                  title: title,
+                  fullBleed: true)
+        .overlay {
+            ZStack {
+                Rectangle().fill(.ultraThinMaterial)
+                Image(systemName: animationImage)
+                    .symbolRenderingMode(.multicolor)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 120, height: 120, alignment: .center)
+                    .scaleEffect(animateGesture ? 1.1 : 1)
             }
-            .padding(.leading)
-            
+            .opacity(animateGesture ? 1 : 0)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: CronicaDesign.Atmosphere.detailHeroHeightForPlatform)
+        .clipped()
+        .accessibilityElement(children: .combine)
+        .accessibilityHidden(true)
+        .onTapGesture(count: 2) {
+            animate(for: store.gesture)
+            viewModel.update(store.gesture)
+        }
+    }
+
+    private var sizeBasedPadMacView: some View {
+        VStack(spacing: 0) {
+            if store.usePostersAsCover || viewModel.showPoster {
+                classicPadMacHeader
+            } else {
+                padMacCinematicHero
+            }
+
             if let season = viewModel.content?.seasons {
                 SeasonListView(
                     showID: id,
@@ -378,6 +339,10 @@ struct ItemContentDetails: View {
         }
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(
+            (store.usePostersAsCover || viewModel.showPoster) ? .automatic : .hidden,
+            for: .navigationBar
+        )
 #elseif os(macOS)
         .navigationTitle(title)
 #endif
@@ -385,31 +350,174 @@ struct ItemContentDetails: View {
             if !isSideInfoPanelShowed && !showInfoBox { showInfoBox = true }
         }
     }
+
+    private var classicPadMacHeader: some View {
+        HStack(alignment: .top) {
+            poster
+
+            VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+                Text(title)
+                    .font(CronicaDesign.Typography.display())
+                    .padding(.bottom, CronicaDesign.Spacing.xs)
+                HStack {
+                    Text(viewModel.content?.itemOverview ?? "")
+                        .lineLimit(10)
+                        .onTapGesture {
+                            showOverview.toggle()
+                        }
+                    Spacer()
+                }
+                .frame(maxWidth: 460)
+                .padding(.bottom, CronicaDesign.Spacing.sm)
+                .popover(isPresented: $showOverview) {
+                    if let overview = viewModel.content?.itemOverview {
+                        VStack {
+                            ScrollView {
+                                Text(overview)
+                                    .padding()
+                            }
+                        }
+                        .frame(minWidth: 200, maxWidth: 400, minHeight: 200, maxHeight: 300, alignment: .center)
+                    }
+                }
+
+                HStack {
+                    watchlistButton
+                        .padding(.trailing)
+
+                    if viewModel.isInWatchlist {
+                        if type == .movie {
+                            watchButton
+                        } else {
+                            favoriteButton
+                        }
+
+                        listButton
+                            .padding(.horizontal)
+                    }
+                }
+            }
+            .frame(width: 360)
+
+            ViewThatFits {
+                quickInformationBoxView
+                    .frame(width: 280)
+                    .padding(.horizontal)
+                    .onAppear {
+                        showInfoBox = false
+                        isSideInfoPanelShowed = true
+                    }
+                    .onDisappear {
+                        showInfoBox = true
+                        isSideInfoPanelShowed = false
+                    }
+                VStack {
+                    Text("")
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.leading)
+    }
+
+    private var padMacCinematicHero: some View {
+        ZStack(alignment: .bottomLeading) {
+            cover
+                .scaleEffect(heroAppeared || reduceMotion ? 1 : 1.04)
+            CronicaDesign.Atmosphere.gradient
+                .allowsHitTesting(false)
+            HStack(alignment: .bottom, spacing: CronicaDesign.Spacing.lg) {
+                VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+                    detailTitleBlock(alignment: .leading, light: true)
+                    detailActionCluster
+                    Text(viewModel.content?.itemOverview ?? "")
+                        .font(CronicaDesign.Typography.sectionSubtitle())
+                        .foregroundStyle(.white.opacity(0.85))
+                        .lineLimit(4)
+                        .frame(maxWidth: 520, alignment: .leading)
+                        .onTapGesture { showOverview.toggle() }
+                }
+                Spacer(minLength: 0)
+                quickInformationBoxView
+                    .frame(width: 260)
+                    .padding()
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
+                    .onAppear {
+                        showInfoBox = false
+                        isSideInfoPanelShowed = true
+                    }
+            }
+            .padding(.horizontal, CronicaDesign.Spacing.xl)
+            .padding(.bottom, CronicaDesign.Spacing.xl)
+            .opacity(heroAppeared ? 1 : 0)
+            .offset(y: heroAppeared || reduceMotion ? 0 : 12)
+        }
+        .frame(height: CronicaDesign.Atmosphere.detailHeroHeightForPlatform)
+        .frame(maxWidth: .infinity)
+        .clipped()
+        .onAppear {
+            if reduceMotion {
+                heroAppeared = true
+            } else {
+                withAnimation(CronicaDesign.Motion.hero) {
+                    heroAppeared = true
+                }
+            }
+        }
+        .popover(isPresented: $showOverview) {
+            if let overview = viewModel.content?.itemOverview {
+                ScrollView {
+                    Text(overview).padding()
+                }
+                .frame(minWidth: 280, maxWidth: 420, minHeight: 200, maxHeight: 320)
+            }
+        }
+    }
 #endif
     
 #if os(tvOS)
     private var sizeBasedTVView: some View {
         VStack {
+            ZStack(alignment: .bottomLeading) {
+                HeroImage(url: viewModel.content?.cardImageLarge, title: title, fullBleed: true)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: CronicaDesign.Atmosphere.detailHeroHeightTV)
+                    .clipped()
+                CronicaDesign.Atmosphere.gradient
+                VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+                    Text(title)
+                        .font(CronicaDesign.Typography.brand())
+                        .foregroundStyle(.white)
+                        .lineLimit(2)
+                    if let genres = viewModel.content?.itemGenres, !genres.isEmpty {
+                        Text(genres)
+                            .font(CronicaDesign.Typography.sectionSubtitle())
+                            .foregroundStyle(.white.opacity(0.8))
+                    }
+                    if let info = viewModel.content?.itemQuickInfo, !info.isEmpty {
+                        Text(info)
+                            .font(CronicaDesign.Typography.caption())
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
+                }
+                .padding(.leading, 64)
+                .padding(.bottom, 48)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.bottom, CronicaDesign.Spacing.md)
+
             HStack {
                 Spacer()
-                poster
                 
                 VStack(alignment: .leading) {
-                    Text(title)
-                        .fontWeight(.semibold)
-                        .font(.title2)
-                        .padding(.bottom)
                     Button {
                         showOverview.toggle()
                     } label: {
                         HStack {
                             Text(viewModel.content?.itemOverview ?? String())
-                                .font(.callout)
-                                .fontDesign(.rounded)
-                                .lineLimit(10)
-                                .onTapGesture {
-                                    showOverview.toggle()
-                                }
+                                .font(CronicaDesign.Typography.sectionSubtitle())
+                                .lineLimit(8)
                             Spacer()
                         }
                         .frame(maxWidth: 700)
@@ -552,35 +660,6 @@ struct ItemContentDetails: View {
         .padding()
         .accessibility(hidden: true)
     }
-    
-#if os(iOS)
-    private var cover: some View {
-        HeroImage(url: viewModel.content?.cardImageLarge,
-                  title: title,
-                  fullBleed: true)
-        .overlay {
-            ZStack {
-                Rectangle().fill(.ultraThinMaterial)
-                Image(systemName: animationImage)
-                    .symbolRenderingMode(.multicolor)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 120, height: 120, alignment: .center)
-                    .scaleEffect(animateGesture ? 1.1 : 1)
-            }
-            .opacity(animateGesture ? 1 : 0)
-        }
-        .frame(maxWidth: .infinity)
-        .frame(height: CronicaDesign.Atmosphere.detailHeroHeight)
-        .clipped()
-        .accessibilityElement(children: .combine)
-        .accessibilityHidden(true)
-        .onTapGesture(count: 2) {
-            animate(for: store.gesture)
-            viewModel.update(store.gesture)
-        }
-    }
-#endif
     
 #if !os(tvOS)
     @ViewBuilder

--- a/Shared/View/Navigation/ExploreView.swift
+++ b/Shared/View/Navigation/ExploreView.swift
@@ -225,7 +225,7 @@ struct ExploreView: View {
         .ignoresSafeArea(.all, edges: .horizontal)
 #endif
 #if os(macOS)
-        .navigationTitle(" ")
+        .navigationTitle("Discover")
 #endif
 #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)

--- a/Shared/View/Navigation/HomeView.swift
+++ b/Shared/View/Navigation/HomeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct HomeView: View {
     static let tag: Screens? = .home
-#if os(tvOS) || os(macOS)
+#if os(tvOS)
     @AppStorage("showOnboarding") private var displayOnboard = false
 #else
     @AppStorage("showOnboarding") private var displayOnboard = true
@@ -31,14 +31,16 @@ struct HomeView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+#if !os(watchOS)
+                HomeBrandHeader(
+                    featuredImage: homeFeaturedImage,
+                    featuredTitle: homeFeaturedTitle,
+                    height: CronicaDesign.Atmosphere.homeHeroHeight,
+                    compactCopy: compactHomeBrandCopy
+                )
+                .padding(.bottom, CronicaDesign.Spacing.xs)
+#endif
 #if os(iOS)
-                if UIDevice.isIPhone {
-                    HomeBrandHeader(
-                        featuredImage: homeFeaturedImage,
-                        featuredTitle: homeFeaturedTitle
-                    )
-                    .padding(.bottom, CronicaDesign.Spacing.xs)
-                }
                 if showReviewBanner { CallToReviewAppView(showView: $showReviewBanner).unredacted() }
 #endif
                 HorizontalUpNextListView(shouldReload: $reloadHome)
@@ -160,8 +162,8 @@ struct HomeView: View {
 #if !os(tvOS)
         .navigationTitle("Home")
 #if os(iOS)
-        .navigationBarTitleDisplayMode(UIDevice.isIPhone ? .inline : .large)
-        .toolbarBackground(UIDevice.isIPhone ? .hidden : .automatic, for: .navigationBar)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
 #endif
 #endif
         .toolbar {
@@ -205,11 +207,12 @@ struct HomeView: View {
             }
 #endif
         }
-#if !os(macOS)
         .sheet(isPresented: $displayOnboard) {
             WelcomeView()
-        }
+#if os(macOS)
+                .frame(width: 520, height: 640)
 #endif
+        }
 #if !os(tvOS)
         .navigationDestination(for: Screens.self) { screen in
             if screen == .notifications {
@@ -224,6 +227,28 @@ struct HomeView: View {
         .task {
             await viewModel.load()
         }
+    }
+
+    private var compactHomeBrandCopy: Bool {
+#if os(macOS)
+        true
+#else
+        false
+#endif
+    }
+
+    private var homeFeaturedImage: URL? {
+        if let episode = upNextViewModel.episodes.first {
+            return episode.episode.itemImageLarge ?? episode.backupImage
+        }
+        return viewModel.trending.first?.cardImageLarge
+    }
+
+    private var homeFeaturedTitle: String? {
+        if let episode = upNextViewModel.episodes.first {
+            return episode.showTitle
+        }
+        return viewModel.trending.first?.itemTitle
     }
     
     private func checkVersion() {
@@ -240,20 +265,6 @@ struct HomeView: View {
     }
     
 #if os(iOS)
-    private var homeFeaturedImage: URL? {
-        if let episode = upNextViewModel.episodes.first {
-            return episode.episode.itemImageLarge ?? episode.backupImage
-        }
-        return viewModel.trending.first?.cardImageLarge
-    }
-
-    private var homeFeaturedTitle: String? {
-        if let episode = upNextViewModel.episodes.first {
-            return episode.showTitle
-        }
-        return viewModel.trending.first?.itemTitle
-    }
-
     private func checkAskForReview() {
         if launchCount < 30 {
             launchCount += 1

--- a/Shared/View/Navigation/SideBarView.swift
+++ b/Shared/View/Navigation/SideBarView.swift
@@ -25,7 +25,7 @@ struct SideBarView: View {
                 }.tag(ExploreView.tag)
                 
                 NavigationLink(value: Screens.watchlist) {
-                    Label("Watchlist", systemImage: "square.stack")
+                    Label("Watchlist", systemImage: "rectangle.on.rectangle")
                 }.tag(WatchlistView.tag)
                 
                 NavigationLink(value: Screens.search) {

--- a/Shared/View/Navigation/TabBarView.swift
+++ b/Shared/View/Navigation/TabBarView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 #if !os(macOS)
-/// A TabBar for switching views, only used on iPhone.
+/// Tab bar shell for iPhone, iPad, tvOS, and visionOS.
 struct TabBarView: View {
     @AppStorage("lastTabSelected") private var tabSelection: Screens?
     var persistence = PersistenceController.shared

--- a/Shared/View/Onboard/WelcomeView.swift
+++ b/Shared/View/Onboard/WelcomeView.swift
@@ -6,13 +6,17 @@
 //
 
 import SwiftUI
-#if !os(macOS)
+#if os(macOS)
+import AppKit
+#endif
+
 /// Onboard experience.
 struct WelcomeView: View {
     @AppStorage("showOnboarding") var displayOnboard = true
     @State private var showPolicy = false
     @State private var appeared = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.openURL) private var openURL
     @StateObject private var store = SettingsStore.shared
 
     var body: some View {
@@ -37,8 +41,12 @@ struct WelcomeView: View {
         }
         .interactiveDismissDisabled(true)
         .onAppear {
-            withAnimation(CronicaDesign.Motion.reduced(reduceMotion)) {
+            if reduceMotion {
                 appeared = true
+            } else {
+                withAnimation(CronicaDesign.Motion.standard) {
+                    appeared = true
+                }
             }
         }
 #if os(iOS)
@@ -114,7 +122,7 @@ struct WelcomeView: View {
         }
         .buttonStyle(.borderedProminent)
         .tint(store.appTheme.color)
-#if os(iOS)
+#if os(iOS) || os(macOS)
         .controlSize(.large)
 #endif
         .opacity(appeared ? 1 : 0)
@@ -122,16 +130,22 @@ struct WelcomeView: View {
 
     private var privacyButton: some View {
         Button {
-#if os(macOS)
-            NSWorkspace.shared.open(URL(string: "https://www.oncronica.com/privacy")!)
-#else
+#if os(iOS)
             showPolicy.toggle()
+#else
+            if let url = URL(string: "https://www.oncronica.com/privacy") {
+#if os(macOS)
+                NSWorkspace.shared.open(url)
+#else
+                openURL(url)
+#endif
+            }
 #endif
         } label: {
             Text("Privacy Policy")
                 .font(CronicaDesign.Typography.caption())
         }
-#if os(iOS)
+#if os(iOS) || os(macOS)
         .buttonStyle(.plain)
         .foregroundStyle(.secondary)
 #endif
@@ -142,4 +156,3 @@ struct WelcomeView: View {
 #Preview {
     WelcomeView()
 }
-#endif

--- a/Shared/View/Settings/AppearanceSetting.swift
+++ b/Shared/View/Settings/AppearanceSetting.swift
@@ -14,15 +14,13 @@ struct AppearanceSetting: View {
 #endif
     var body: some View {
         Form {
-#if os(iOS)
-            if UIDevice.isIPhone {
-                Section {
-                    Toggle("Prefer Poster in Details Page", isOn: $store.usePostersAsCover)
-                } header: {
-                    Text("Details Page")
-                } footer: {
-                    Text("By default, details use a full-bleed cover image. Turn this on to keep the classic poster layout.")
-                }
+#if os(iOS) || os(macOS)
+            Section {
+                Toggle("Prefer Poster in Details Page", isOn: $store.usePostersAsCover)
+            } header: {
+                Text("Details Page")
+            } footer: {
+                Text("By default, details use a full-bleed cover image. Turn this on to keep the classic poster layout.")
             }
 #endif
             


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Extends the cinematic iOS redesign to iPad, Mac, and tvOS so Home and Details share the same content-first visual language, with platform-appropriate sizing and focus behavior.

## Changes
- **Home:** `HomeBrandHeader` on iPad/Mac/tvOS with platform hero heights; inline/hidden nav chrome on iPad
- **Details:** full-bleed cinematic hero for iPad/Mac (poster layout remains opt-in); tvOS backdrop hero above focusable actions
- **Welcome:** available on Mac; Privacy uses system open URL on Mac/tvOS
- **Chrome:** Discover naming in `Screens`, Mac Explore title, Watchlist sidebar icon aligned with iOS
- **Appearance:** Prefer Poster toggle on iPad and Mac
- **Tokens:** pad/Mac/TV atmosphere heights; slightly stronger tvOS glass/material treatment

## Test plan
- [ ] iPad Home: brand hero under clear nav; rails still navigate
- [ ] iPad/Mac Details: cinematic cover by default; Prefer Poster restores classic header
- [ ] Mac: Welcome sheet on first launch; sidebar Discover/Watchlist icons look correct
- [ ] tvOS Home: brand hero + horizontal safe areas; focus still works on Up Next
- [ ] tvOS Details: backdrop hero, focused Add/Watch/Favorite actions still reachable
- [ ] Reduce Motion / Reduce Transparency still behave sensibly on each platform

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

