### PR TITLE
Final redesign ship: cherry accent, hygiene, backup, widget

### DIFF
--- a/Cronica.xcodeproj/project.pbxproj
+++ b/Cronica.xcodeproj/project.pbxproj
@@ -2007,7 +2007,7 @@
 				CODE_SIGN_ENTITLEMENTS = "AppleWatch/Configuration/Cronica Watch App.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"AppleWatch/Preview Content\"";
 				DEVELOPMENT_TEAM = S5A7774228;
 				ENABLE_PREVIEWS = YES;
@@ -2021,7 +2021,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.0;
+				MARKETING_VERSION = 2.7.8;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story.watchkitapp;
 				PRODUCT_NAME = Cronica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2043,7 +2043,7 @@
 				CODE_SIGN_ENTITLEMENTS = "AppleWatch/Configuration/Cronica Watch App.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"AppleWatch/Preview Content\"";
 				DEVELOPMENT_TEAM = S5A7774228;
 				ENABLE_PREVIEWS = YES;
@@ -2057,7 +2057,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.0;
+				MARKETING_VERSION = 2.7.8;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story.watchkitapp;
 				PRODUCT_NAME = Cronica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2217,7 +2217,7 @@
 				CODE_SIGN_ENTITLEMENTS = Shared/Configuration/Cronica.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = S5A7774228;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
@@ -2236,7 +2236,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 2.7.7;
+				MARKETING_VERSION = 2.7.8;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story;
 				PRODUCT_NAME = Cronica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2266,7 +2266,7 @@
 				CODE_SIGN_ENTITLEMENTS = Shared/Configuration/Cronica.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = S5A7774228;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
@@ -2285,7 +2285,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 2.7.7;
+				MARKETING_VERSION = 2.7.8;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story;
 				PRODUCT_NAME = Cronica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2311,7 +2311,7 @@
 				CODE_SIGN_ENTITLEMENTS = CronicaWidget/Configuration/CronicaWidgetExtension.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = S5A7774228;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2324,7 +2324,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.6.5;
+				MARKETING_VERSION = 2.7.8;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -2347,7 +2347,7 @@
 				CODE_SIGN_ENTITLEMENTS = CronicaWidget/Configuration/CronicaWidgetExtension.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = S5A7774228;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2360,7 +2360,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.6.5;
+				MARKETING_VERSION = 2.7.8;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -2381,7 +2381,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = S5A7774228;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2404,7 +2404,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = S5A7774228;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/CronicaWidget/CronicaWidget.swift
+++ b/CronicaWidget/CronicaWidget.swift
@@ -20,7 +20,7 @@ struct Provider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
         Task {
-            let nextUpdate = Date().addingTimeInterval(86400) // 24 hours in seconds
+            let nextUpdate = Date().addingTimeInterval(86400) // 24 hours
             do {
                 let result = try await NetworkService.shared.fetchItems(from: "trending/all/day")
                 var content = [ItemContent]()
@@ -35,10 +35,10 @@ struct Provider: TimelineProvider {
                     content.append(itemContent)
                 }
                 let entry = ItemContentEntry(date: .now, item: content)
-                let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
-                completion(timeline)
+                completion(Timeline(entries: [entry], policy: .after(nextUpdate)))
             } catch {
-                print("Error: \(error.localizedDescription)")
+                let entry = ItemContentEntry(date: .now, item: [])
+                completion(Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(60 * 60))))
             }
         }
     }
@@ -77,8 +77,3 @@ struct CronicaWidget: Widget {
         .supportedFamilies([.systemMedium])
     }
 }
-
-//#Preview {
-//    CronicaWidgetEntryView(entry: ItemContentEntry(date: Date(), item: [ItemContent.placeholder]))
-//        .previewContext(WidgetPreviewContext(family: .systemMedium))
-//}

--- a/CronicaWidget/Views/ItemContentList.swift
+++ b/CronicaWidget/Views/ItemContentList.swift
@@ -54,7 +54,7 @@ private struct PosterImage: View {
     let item: ItemContent
     @State private var showPlaceholder = false
     var body: some View {
-        Link(destination: URL(string: item.itemContentID)!) {
+        Link(destination: URL(string: "cronica://\(item.itemContentID)") ?? URL(string: "cronica://")!) {
             if let placeholder = item.placeholderImagePath {
                 Image(placeholder)
                     .resizable()

--- a/Shared/Configuration/Cronica-Info.plist
+++ b/Shared/Configuration/Cronica-Info.plist
@@ -12,7 +12,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Viewer</string>
 			<key>CFBundleURLName</key>
-			<string></string>
+			<string>dev.alexandremadeira.Story</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>cronica</string>

--- a/Shared/Configuration/CronicaApp.swift
+++ b/Shared/Configuration/CronicaApp.swift
@@ -15,8 +15,6 @@ struct CronicaApp: App {
     var persistence = PersistenceController.shared
     private let backgroundIdentifier = "dev.alexandremadeira.cronica.refreshContent"
     @Environment(\.scenePhase) private var scene
-    @State private var widgetItem: ItemContent?
-    @State private var notificationItem: ItemContent?
     @State private var selectedItem: ItemContent?
     @State private var showFeedbackForm = false
     @State private var showAbout = false
@@ -64,16 +62,8 @@ struct CronicaApp: App {
                 }
 #endif
                 .onOpenURL { url in
-                    let urlString = url.absoluteString
-                    if urlString.hasPrefix("cronica://") {
-                        let urlSubstring = urlString.dropFirst("cronica://".count)
-                        Task {
-                            await fetchContent(for: String(urlSubstring))
-                        }
-                    } else {
-                        Task {
-                            await fetchContent(for: url.absoluteString)
-                        }
+                    Task {
+                        await openDeepLink(url)
                     }
                 }
                 .sheet(item: $selectedItem) { item in
@@ -216,6 +206,30 @@ struct CronicaApp: App {
 #endif
     }
     
+    private func openDeepLink(_ url: URL) async {
+        if let contentID = Self.contentID(from: url) {
+            await fetchContent(for: contentID)
+        }
+    }
+
+    /// Accepts `cronica://123@0`, bare `123@0`, or `https://www.oncronica.com/details?id=123@0`.
+    static func contentID(from url: URL) -> String? {
+        let absolute = url.absoluteString
+        if absolute.hasPrefix("cronica://") {
+            let id = String(absolute.dropFirst("cronica://".count))
+            return id.isEmpty ? nil : id.removingPercentEncoding ?? id
+        }
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+           let id = components.queryItems?.first(where: { $0.name == "id" })?.value,
+           !id.isEmpty {
+            return id
+        }
+        if absolute.contains("@"), !absolute.contains("://") {
+            return absolute
+        }
+        return nil
+    }
+
     private func fetchContent(for id: String) async {
         if selectedItem != nil { selectedItem = nil }
         let type = id.last ?? "0"
@@ -223,7 +237,7 @@ struct CronicaApp: App {
         if type == "1" {
             media = .tvShow
         }
-        let contentID = id.dropLast(2)
+        let contentID = String(id.dropLast(2))
         guard let contentIDNumber = Int(contentID) else { return }
         let item = try? await NetworkService.shared.fetchItem(id: contentIDNumber, type: media)
         guard let item else { return }
@@ -253,36 +267,27 @@ struct CronicaApp: App {
 #if os(iOS)
     // Fetch the latest updates from api.
     private func handleAppRefresh(task: BGAppRefreshTask?) {
-        if let task {
-            scheduleAppRefresh()
-            let queue = OperationQueue()
-            queue.maxConcurrentOperationCount = 1
-            task.expirationHandler = {
-                // After all operations are cancelled, the completion block below is called to set the task to complete.
-                queue.cancelAllOperations()
-            }
-            queue.addOperation {
-                Task {
-                    await BackgroundManager.shared.handleWatchingContentRefresh()
-                    BackgroundManager.shared.lastWatchingRefresh = Date()
-                    await BackgroundManager.shared.handleUpcomingContentRefresh()
-                    BackgroundManager.shared.lastUpcomingRefresh = Date()
-                    await BackgroundManager.shared.handleAppRefreshMaintenance()
-                    BackgroundManager.shared.lastMaintenance = Date()
-                }
-            }
-            task.setTaskCompleted(success: true)
+        guard let task else { return }
+        scheduleAppRefresh()
+        let refreshTask = Task {
+            await BackgroundManager.shared.handleWatchingContentRefresh()
+            await BackgroundManager.shared.handleUpcomingContentRefresh()
+            await BackgroundManager.shared.handleAppRefreshMaintenance()
+        }
+        task.expirationHandler = {
+            refreshTask.cancel()
+        }
+        Task {
+            await refreshTask.value
+            task.setTaskCompleted(success: !Task.isCancelled)
         }
     }
 #elseif os(macOS)
     private func handleAppRefresh() {
         Task {
             await BackgroundManager.shared.handleWatchingContentRefresh()
-            BackgroundManager.shared.lastWatchingRefresh = Date()
             await BackgroundManager.shared.handleUpcomingContentRefresh()
-            BackgroundManager.shared.lastUpcomingRefresh = Date()
             await BackgroundManager.shared.handleAppRefreshMaintenance()
-            BackgroundManager.shared.lastMaintenance = Date()
         }
     }
 #endif

--- a/Shared/Configuration/Key.swift
+++ b/Shared/Configuration/Key.swift
@@ -7,10 +7,23 @@
 
 import Foundation
 
-/// The Keys used for the TMDb API and the TelemetryDeck service.
+/// API keys for TMDb and Aptabase.
 ///
-/// The values for each key is defined in an environment variable.
+/// Leave these empty in the repository. Inject real values via local edits,
+/// CI secrets, or an untracked override before shipping.
 struct Key {
     static let tmdbApi = ""
     static let aptabaseClientKey: String? = ""
+
+    static var hasTMDbKey: Bool {
+        !tmdbApi.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    static var aptabaseKeyIfAvailable: String? {
+        guard let key = aptabaseClientKey?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !key.isEmpty else {
+            return nil
+        }
+        return key
+    }
 }

--- a/Shared/Extensions/ItemContent-Extensions.swift
+++ b/Shared/Extensions/ItemContent-Extensions.swift
@@ -206,7 +206,8 @@ extension ItemContent {
 #if os(tvOS)
         return NetworkService.urlBuilder(size: .w780, path: posterPath)
 #else
-        return NetworkService.urlBuilder(size: .w500, path: posterPath)
+        // Grid posters are ~160pt wide; w300 is enough and keeps lists light.
+        return NetworkService.urlBuilder(size: .medium, path: posterPath)
 #endif
     }
     var posterImageLarge: URL? {
@@ -219,7 +220,7 @@ extension ItemContent {
 #if os(tvOS)
         return NetworkService.urlBuilder(size: .w780, path: backdropPath)
 #else
-        return NetworkService.urlBuilder(size: .w500, path: backdropPath)
+        return NetworkService.urlBuilder(size: .medium, path: backdropPath)
 #endif
     }
     var cardImageLarge: URL? {

--- a/Shared/Localization/Localizable.xcstrings
+++ b/Shared/Localization/Localizable.xcstrings
@@ -1,6 +1,50 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Imported %lld titles. Skipped %lld that were already in your watchlist." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Imported %lld titles. Skipped %lld that were already in your watchlist."
+          }
+        }
+      }
+    },
+    "Restore failed. Check that the file is a Cronica backup." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restore failed. Check that the file is a Cronica backup."
+          }
+        }
+      }
+    },
+    "Couldn\u2019t open that file." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn\u2019t open that file."
+          }
+        }
+      }
+    },
+    "Exports your watchlist as JSON. Restore skips titles that are already in your library." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exports your watchlist as JSON. Restore skips titles that are already in your library."
+          }
+        }
+      }
+    },
     "We couldn\u2019t finish this search. Check your connection and try again." : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Shared/Manager/BackgroundManager.swift
+++ b/Shared/Manager/BackgroundManager.swift
@@ -44,25 +44,39 @@ final class BackgroundManager {
 		}
 	}
 	
-	func handleWatchingContentRefresh() async {
+	private let minimumRefreshInterval: TimeInterval = 6 * 60 * 60
+
+	func handleWatchingContentRefresh(force: Bool = false) async {
+		if !force, let last = lastWatchingRefresh, Date().timeIntervalSince(last) < minimumRefreshInterval {
+			return
+		}
 		let items = self.fetchWatchingItems()
 		await self.fetchUpdates(items: items)
+		lastWatchingRefresh = Date()
 	}
 	
-	func handleUpcomingContentRefresh() async {
+	func handleUpcomingContentRefresh(force: Bool = false) async {
+		if !force, let last = lastUpcomingRefresh, Date().timeIntervalSince(last) < minimumRefreshInterval {
+			return
+		}
 		var items = [WatchlistItem]()
 		let upcomingItems = self.fetchUpcomingItems()
 		items.append(contentsOf: upcomingItems)
 		if items.isEmpty { return }
 		await self.fetchUpdates(items: items)
+		lastUpcomingRefresh = Date()
 	}
 	
-	func handleAppRefreshMaintenance() async {
+	func handleAppRefreshMaintenance(force: Bool = false) async {
+		if !force, let last = lastMaintenance, Date().timeIntervalSince(last) < minimumRefreshInterval {
+			return
+		}
 		var items = [WatchlistItem]()
 		let releasedAndEndedItems = self.fetchReleasedItems()
 		items.append(contentsOf: releasedAndEndedItems)
 		if items.isEmpty { return }
 		await self.fetchUpdates(items: items)
+		lastMaintenance = Date()
 	}
 	
 	private func fetchWatchingItems() -> [WatchlistItem] {
@@ -122,16 +136,12 @@ final class BackgroundManager {
 				// if the item is already released, archive or watched
 				// the need for constant updates are not there.
 				// So, to save resources, they will update less frequently.
-				if item.isMovie {
-					await update(item)
-				} else {
-					if item.isArchive || item.itemSchedule == .ended || item.isWatched {
-						if item.itemLastUpdateDate.hasPassedTwoWeek() {
-							await update(item)
-						}
-					} else {
+				if item.isArchive || item.isWatched || (!item.isMovie && item.itemSchedule == .ended) {
+					if item.itemLastUpdateDate.hasPassedTwoWeek() {
 						await update(item)
 					}
+				} else {
+					await update(item)
 				}
 			}
 		}
@@ -150,9 +160,8 @@ final class BackgroundManager {
 			if content.itemStatus == .cancelled {
 				notifications.removeNotification(identifier: content.itemContentID)
 			}
-			// In order to avoid passing the limit of local notifications,
-			// the app will only register when it's less than two months away
-			// from release date.
+			// Stay under local notification limits by only scheduling
+			// when release is less than two weeks away.
 			if content.itemFallbackDate.isLessThanTwoWeeksAway() {
 				notifications.schedule(content)
 			}

--- a/Shared/Manager/CronicaTelemetry.swift
+++ b/Shared/Manager/CronicaTelemetry.swift
@@ -19,8 +19,8 @@ struct CronicaTelemetry {
     private init() { }
     
     func setup() {
-#if !targetEnvironment(simulator) || !DEBUG
-        guard let aptabaseKey = Key.aptabaseClientKey else { return }
+#if !DEBUG
+        guard let aptabaseKey = Key.aptabaseKeyIfAvailable else { return }
         Aptabase.shared.initialize(appKey: aptabaseKey)
         Aptabase.shared.trackEvent("app_started")
 #endif
@@ -33,6 +33,7 @@ struct CronicaTelemetry {
 #if targetEnvironment(simulator) || DEBUG
         logger.warning("\(message), for: \(id)")
 #else
+        guard Key.aptabaseKeyIfAvailable != nil else { return }
         Aptabase.shared.trackEvent(id, with: ["Message": message])
 #endif
     }

--- a/Shared/Model/WatchlistItem+CoreDataClass.swift
+++ b/Shared/Model/WatchlistItem+CoreDataClass.swift
@@ -17,40 +17,36 @@ public class WatchlistItem: NSManagedObject, Codable {
         }
         self.init(context: context)
         
-        do {
-            let values = try decoder.container(keyedBy: CodingKeys.self)
-            id = try values.decode(Int64.self, forKey: .id)
-            title = try values.decode(String.self, forKey: .title)
-            contentID = try values.decode(String.self, forKey: .contentID)
-            image = try values.decode(URL?.self, forKey: .image)
-            watchedEpisodes = try values.decode(String.self, forKey: .watchedEpisodes)
-            watched = try values.decode(Bool.self, forKey: .watched)
-            favorite = try values.decode(Bool.self, forKey: .favorite)
-            contentType = try values.decode(Int64.self, forKey: .contentType)
-            schedule = try values.decode(Int16.self, forKey: .schedule)
-            largeCardImage = try values.decode(URL?.self, forKey: .largeCardImage)
-            largePosterImage = try values.decode(URL?.self, forKey: .largePosterImage)
-            mediumPosterImage = try values.decode(URL?.self, forKey: .mediumPosterImage)
-            shouldNotify = try values.decode(Bool.self, forKey: .shouldNotify)
-            isArchive = try values.decode(Bool.self, forKey: .isArchive)
-            nextEpisodeNumber = try values.decode(Int64.self, forKey: .nextEpisodeNumber)
-            nextSeasonNumber = try values.decode(Int64.self, forKey: .nextSeasonNumber)
-            nextEpisodeNumberUpNext = try values.decode(Int64.self, forKey: .nextEpisodeNumberUpNext)
-            seasonNumberUpNext = try values.decode(Int64.self, forKey: .seasonNumberUpNext)
-            displayOnUpNext = try values.decode(Bool.self, forKey: .displayOnUpNext)
-            isPin = try values.decode(Bool.self, forKey: .isPin)
-            lastEpisodeNumber = try values.decode(Int64.self, forKey: .lastEpisodeNumber)
-            lastSelectedSeason = try values.decode(Int64.self, forKey: .lastSelectedSeason)
-            userNotes = try values.decode(String.self, forKey: .userNotes)
-            userRating = try values.decode(Int64.self, forKey: .userRating)
-            isWatching = try values.decode(Bool.self, forKey: .isWatching)
-			posterPath = try values.decode(String?.self, forKey: .posterPath)
-			backdropPath = try values.decode(String?.self, forKey: .backdropPath)
-			firstAirDate = try values.decode(Date?.self, forKey: .firstAirDate)
-			movieReleaseDate = try values.decode(Date?.self, forKey: .movieReleaseDate)
-        } catch {
-            print(error.localizedDescription)
-        }
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        id = try values.decode(Int64.self, forKey: .id)
+        title = try values.decode(String.self, forKey: .title)
+        contentID = try values.decode(String.self, forKey: .contentID)
+        image = try values.decodeIfPresent(URL.self, forKey: .image)
+        watchedEpisodes = try values.decodeIfPresent(String.self, forKey: .watchedEpisodes) ?? ""
+        watched = try values.decodeIfPresent(Bool.self, forKey: .watched) ?? false
+        favorite = try values.decodeIfPresent(Bool.self, forKey: .favorite) ?? false
+        contentType = try values.decode(Int64.self, forKey: .contentType)
+        schedule = try values.decodeIfPresent(Int16.self, forKey: .schedule) ?? 0
+        largeCardImage = try values.decodeIfPresent(URL.self, forKey: .largeCardImage)
+        largePosterImage = try values.decodeIfPresent(URL.self, forKey: .largePosterImage)
+        mediumPosterImage = try values.decodeIfPresent(URL.self, forKey: .mediumPosterImage)
+        shouldNotify = try values.decodeIfPresent(Bool.self, forKey: .shouldNotify) ?? false
+        isArchive = try values.decodeIfPresent(Bool.self, forKey: .isArchive) ?? false
+        nextEpisodeNumber = try values.decodeIfPresent(Int64.self, forKey: .nextEpisodeNumber) ?? 0
+        nextSeasonNumber = try values.decodeIfPresent(Int64.self, forKey: .nextSeasonNumber) ?? 0
+        nextEpisodeNumberUpNext = try values.decodeIfPresent(Int64.self, forKey: .nextEpisodeNumberUpNext) ?? 0
+        seasonNumberUpNext = try values.decodeIfPresent(Int64.self, forKey: .seasonNumberUpNext) ?? 0
+        displayOnUpNext = try values.decodeIfPresent(Bool.self, forKey: .displayOnUpNext) ?? false
+        isPin = try values.decodeIfPresent(Bool.self, forKey: .isPin) ?? false
+        lastEpisodeNumber = try values.decodeIfPresent(Int64.self, forKey: .lastEpisodeNumber) ?? 0
+        lastSelectedSeason = try values.decodeIfPresent(Int64.self, forKey: .lastSelectedSeason) ?? 0
+        userNotes = try values.decodeIfPresent(String.self, forKey: .userNotes) ?? ""
+        userRating = try values.decodeIfPresent(Int64.self, forKey: .userRating) ?? 0
+        isWatching = try values.decodeIfPresent(Bool.self, forKey: .isWatching) ?? false
+        posterPath = try values.decodeIfPresent(String.self, forKey: .posterPath)
+        backdropPath = try values.decodeIfPresent(String.self, forKey: .backdropPath)
+        firstAirDate = try values.decodeIfPresent(Date.self, forKey: .firstAirDate)
+        movieReleaseDate = try values.decodeIfPresent(Date.self, forKey: .movieReleaseDate)
     }
     
     public func encode(to encoder: Encoder) throws {

--- a/Shared/Network/NetworkService.swift
+++ b/Shared/Network/NetworkService.swift
@@ -145,6 +145,7 @@ final class NetworkService: Sendable {
     }
     
     private func fetch<T: Decodable>(url: URL) async throws -> T {
+        guard Key.hasTMDbKey else { throw NetworkError.invalidApi }
         let (data, response) = try await URLSession.shared.data(from: url)
         guard let httpResponse = response as? HTTPURLResponse else { throw NetworkError.invalidResponse }
         let responseError = handleNetworkResponses(response: httpResponse)

--- a/Shared/Store/SettingsStore.swift
+++ b/Shared/Store/SettingsStore.swift
@@ -13,7 +13,7 @@ final class SettingsStore: ObservableObject {
     @AppStorage("showOnboarding") var displayOnboard = true
     @AppStorage("displayDeveloperSettings") var displayDeveloperSettings = false
     @AppStorage("gesture") var gesture: UpdateItemProperties = .favorite
-    @AppStorage("appThemeColor") var appTheme: AppThemeColors = .blue
+    @AppStorage("appThemeColor") var appTheme: AppThemeColors = .cherry
 #if os(iOS)
     @AppStorage("watchlistStyle") var watchlistStyle: SectionDetailsPreferredStyle = UIDevice.isIPhone ? .list : .poster
 #else

--- a/Shared/View/Modifiers/AppThemeModifier.swift
+++ b/Shared/View/Modifiers/AppThemeModifier.swift
@@ -20,7 +20,7 @@ struct AppThemeModifier: ViewModifier {
 
 struct AppTintModifier: ViewModifier {
     static let defaultsKey = "user_theme"
-    @AppStorage("appThemeColor") var appTheme: AppThemeColors = .blue
+    @AppStorage("appThemeColor") var appTheme: AppThemeColors = .cherry
     func body(content: Content) -> some View {
         content
             .tint(appTheme.color)

--- a/Shared/View/Settings/AppearanceSetting.swift
+++ b/Shared/View/Settings/AppearanceSetting.swift
@@ -92,15 +92,21 @@ struct AppearanceSetting: View {
 #endif
     }
     
+    /// Prefer cinematic reds that match the popcorn icons; keep the rest after.
+    private var accentColorOptions: [AppThemeColors] {
+        let preferred: [AppThemeColors] = [.cherry, .rubyRed, .coral, .fireballRed, .burntOrange]
+        return preferred + AppThemeColors.allCases.filter { !preferred.contains($0) }
+    }
+
     private var accentColor: some View {
         VStack(alignment: .leading) {
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack {
-                        ForEach(AppThemeColors.allCases) { item in
+                        ForEach(accentColorOptions) { item in
                             colorButton(for: item)
-                                .padding(.leading, item == AppThemeColors.allCases.first ? 16 : 0)
-                                .padding(.trailing, item == AppThemeColors.allCases.last ? 16 : 0)
+                                .padding(.leading, item == accentColorOptions.first ? 16 : 0)
+                                .padding(.trailing, item == accentColorOptions.last ? 16 : 0)
                                 .padding(.horizontal, 4)
                         }
                     }

--- a/Shared/View/Settings/WatchlistSettingsView.swift
+++ b/Shared/View/Settings/WatchlistSettingsView.swift
@@ -16,7 +16,9 @@ struct WatchlistSettingsView: View {
     @State private var showFilePicker = false
     @State private var exportUrl: URL?
     @Environment(\.managedObjectContext) private var context
-    @State private var hasImported = false
+    @State private var isImporting = false
+    @State private var importMessage: String?
+    @State private var showImportResult = false
     let background = BackgroundManager.shared
     var body: some View {
         Form {
@@ -79,7 +81,7 @@ struct WatchlistSettingsView: View {
 #endif
             } footer: {
 #if os(iOS)
-                Text("Backup/Restore is in beta, only use it to export your data or to import if you're switching your iCloud account, there's no logic at the moment to avoid duplication.")
+                Text("Exports your watchlist as JSON. Restore skips titles that are already in your library.")
 #endif
             }
             .sheet(isPresented: $showExportShareSheet) {
@@ -91,12 +93,17 @@ struct WatchlistSettingsView: View {
             .fileImporter(isPresented: $showFilePicker, allowedContentTypes: [.json]) { result in
                 switch result {
                 case .success(let success):
-                    if success.startAccessingSecurityScopedResource() {
-                        importJSON(success)
-                    }
+                    importJSON(success)
                 case .failure(let failure):
                     CronicaTelemetry.shared.handleMessage(failure.localizedDescription, for: "SyncSettings.fileImporter")
+                    importMessage = String(localized: "Couldn’t open that file.")
+                    showImportResult = true
                 }
+            }
+            .alert("Restore", isPresented: $showImportResult) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(importMessage ?? "")
             }
 #endif
 #endif
@@ -116,9 +123,13 @@ struct WatchlistSettingsView: View {
         Button {
             showFilePicker.toggle()
         } label: {
-            Text("Restore")
+            if isImporting {
+                ProgressView()
+            } else {
+                Text("Restore")
+            }
         }
-        .disabled(hasImported)
+        .disabled(isImporting)
     }
     
     private var exportButton: some View {
@@ -151,9 +162,9 @@ extension WatchlistSettingsView {
                     self.updatingItems.toggle()
                 }
             }
-            await background.handleWatchingContentRefresh()
-            await background.handleUpcomingContentRefresh()
-            await background.handleAppRefreshMaintenance()
+            await background.handleWatchingContentRefresh(force: true)
+            await background.handleUpcomingContentRefresh(force: true)
+            await background.handleAppRefreshMaintenance(force: true)
             await MainActor.run {
                 withAnimation {
                     self.updatingItems.toggle()
@@ -174,7 +185,10 @@ extension WatchlistSettingsView {
                 let jsonData = try JSONEncoder().encode(items)
                 if let jsonString = String(data: jsonData, encoding: .utf8) {
                     if let tempUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
-                        let pathUrl = tempUrl.appending(component: "CronicaExport \(Date().formatted(date: .abbreviated, time: .omitted)).json")
+                        let formatter = DateFormatter()
+                        formatter.locale = Locale(identifier: "en_US_POSIX")
+                        formatter.dateFormat = "yyyy-MM-dd"
+                        let pathUrl = tempUrl.appending(component: "CronicaExport-\(formatter.string(from: Date())).json")
                         try jsonString.write(to: pathUrl, atomically: true, encoding: .utf8)
                         exportUrl = pathUrl
                         showExportShareSheet.toggle()
@@ -189,20 +203,46 @@ extension WatchlistSettingsView {
     }
     
     private func importJSON(_ url: URL) {
+        let accessed = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessed {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+        isImporting = true
+        defer { isImporting = false }
         do {
+            let existingRequest = WatchlistItem.fetchRequest()
+            let existingItems = try context.fetch(existingRequest)
+            var existingIDs = Set(existingItems.compactMap(\.contentID))
+
             let jsonData = try Data(contentsOf: url)
             let decoder = JSONDecoder()
-            decoder.userInfo[.context] = PersistenceController.shared.container.viewContext
-            _ = try decoder.decode([WatchlistItem].self, from: jsonData)
-            try context.save()
-            hasImported.toggle()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                withAnimation {
-                    hasImported = false
+            decoder.userInfo[.context] = context
+            let decoded = try decoder.decode([WatchlistItem].self, from: jsonData)
+            var imported = 0
+            var skipped = 0
+            for item in decoded {
+                let id = item.contentID ?? item.itemContentID
+                if existingIDs.contains(id) {
+                    context.delete(item)
+                    skipped += 1
+                } else {
+                    existingIDs.insert(id)
+                    imported += 1
                 }
             }
+            try context.save()
+            importMessage = String(
+                format: String(localized: "Imported %lld titles. Skipped %lld that were already in your watchlist."),
+                imported,
+                skipped
+            )
+            showImportResult = true
         } catch {
             CronicaTelemetry.shared.handleMessage(error.localizedDescription, for: "SyncSettings.importJSON.failed")
+            importMessage = String(localized: "Restore failed. Check that the file is a Cronica backup.")
+            showImportResult = true
         }
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
All-in-one wrap-up for the cinematic redesign: production hygiene, a better default accent, and the remaining lightweight readiness items. Trakt and other new integrations stay deferred.

## Accent & icons
- Default accent is now **cherry** (matches the red/white popcorn icons) instead of blue
- Accent picker leads with cinematic reds: cherry, ruby, coral, fireball, burnt orange
- Existing users keep their saved accent via App Storage

## Production hygiene
- Version aligned to **2.7.8** across app / Watch / Widget; build bumped to **2**
- Empty TMDb / Aptabase keys are gated (no bogus network/telemetry init)
- Background refresh completes the BG task after work finishes; 6h throttle (manual Update Items still forced)
- Watched/archived movies share the two-week update throttle with TV
- Grid posters/cards use **w300** instead of w500

## Features hardened
- **Backup/Restore:** dedupe by `contentID`, security-scoped resource cleanup, POSIX export filenames, result alerts
- **Widget:** always completes timeline (including errors); opens `cronica://id@media`
- **Deep links:** supports `cronica://…` and `oncronica.com/details?id=…`

## Before App Store
- Inject real `Key.tmdbApi` / Aptabase values locally or via CI (still empty in repo by design)

## Test plan
- [ ] Fresh install: accent defaults to cherry; Welcome/Home/Details still look cinematic
- [ ] Appearance: cherry is first in the accent strip; changing accent still tints CTAs
- [ ] Watchlist Settings → Backup → Restore: duplicates skipped; alert shows counts
- [ ] Widget tap opens the correct title in-app
- [ ] `cronica://550@0` and a web details URL with `id=` both open details
- [ ] With empty TMDb key, network calls fail cleanly as invalid API (no crash)
- [ ] Versions show 2.7.8 on all targets in Xcode

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

