### PR TITLE
Bring cinematic redesign to Apple Watch

### DIFF
--- a/AppleWatch/Configuration/CronicaWatchApp.swift
+++ b/AppleWatch/Configuration/CronicaWatchApp.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct CronicaWatchApp: App {
     var persistence = PersistenceController.shared
     @AppStorage("selectedView") var selectedView: Screens?
+    @StateObject private var settings = SettingsStore.shared
     init() {
         CronicaTelemetry.shared.setup()
     }
@@ -18,6 +19,12 @@ struct CronicaWatchApp: App {
         WindowGroup {
             NavigationSplitView {
                 List(selection: $selectedView) {
+                    Section {
+                        Text("Cronica")
+                            .font(CronicaDesign.Typography.brand())
+                            .foregroundStyle(settings.appTheme.color)
+                            .listRowBackground(Color.clear)
+                    }
                     ForEach(Screens.allCases) { screen in
                         Label(screen.title, systemImage: screen.toSFSymbols).tag(screen)
                     }
@@ -31,6 +38,7 @@ struct CronicaWatchApp: App {
                 default: WatchlistView().environment(\.managedObjectContext, persistence.container.viewContext)
                 }
             }
+            .tint(settings.appTheme.color)
         }
     }
 }

--- a/AppleWatch/Views/Components/AboutSectionView.swift
+++ b/AppleWatch/Views/Components/AboutSectionView.swift
@@ -9,34 +9,37 @@ import SwiftUI
 
 struct AboutSectionView: View {
     let about: String?
-	@State private var showAbout = false
+    @State private var showAbout = false
     var body: some View {
         if let about {
             if !about.isEmpty {
                 Section {
-                    VStack(alignment: .leading) {
+                    VStack(alignment: .leading, spacing: CronicaDesign.Spacing.xxs) {
                         Text(about)
-							.lineLimit(showAbout ? nil : 4)
+                            .font(CronicaDesign.Typography.caption())
+                            .lineLimit(showAbout ? nil : 4)
                     }
-					.onTapGesture {
-						withAnimation { showAbout.toggle() }
-					}
-					.padding(.zero)
+                    .onTapGesture {
+                        withAnimation(CronicaDesign.Motion.standard) { showAbout.toggle() }
+                    }
+                    .padding(.zero)
                 } header: {
                     HStack {
                         Text("About")
-							.textCase(.uppercase)
-							.foregroundColor(.secondary)
+                            .font(CronicaDesign.Typography.caption())
+                            .textCase(.uppercase)
+                            .foregroundColor(.secondary)
                         Spacer()
                     }
-					.padding([.horizontal, .top])
+                    .padding(.horizontal, CronicaDesign.Spacing.sm)
+                    .padding(.top, CronicaDesign.Spacing.sm)
                 }
-				.padding([.horizontal, .bottom])
+                .padding(.horizontal, CronicaDesign.Spacing.sm)
+                .padding(.bottom, CronicaDesign.Spacing.sm)
             }
         }
     }
 }
-
 
 #Preview {
     AboutSectionView(about: ItemContent.example.itemOverview)

--- a/AppleWatch/Views/Components/EmptyListView.swift
+++ b/AppleWatch/Views/Components/EmptyListView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct EmptyListView: View {
     var body: some View {
         ContentUnavailableView("Your list is empty.", systemImage: "rectangle.on.rectangle")
-            .padding()
+            .padding(CronicaDesign.Spacing.md)
     }
 }
 

--- a/AppleWatch/Views/Components/EpisodeRow.swift
+++ b/AppleWatch/Views/Components/EpisodeRow.swift
@@ -15,7 +15,7 @@ struct EpisodeRow: View {
     private let persistence = PersistenceController.shared
     @State private var isWatched: Bool = false
     var body: some View {
-        HStack {
+        HStack(spacing: CronicaDesign.Spacing.sm) {
             LazyImage(url: episode.itemImageMedium) { state in
                 if let image = state.image {
                     image
@@ -34,7 +34,7 @@ struct EpisodeRow: View {
             .frame(width: DrawingConstants.imageWidth,
                    height: DrawingConstants.imageHeight)
             .clipShape(
-                RoundedRectangle(cornerRadius: DrawingConstants.imageRadius,
+                RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                  style: .continuous)
             )
             .overlay {
@@ -45,26 +45,25 @@ struct EpisodeRow: View {
                             .foregroundColor(.white)
                     }
                     .clipShape(
-                        RoundedRectangle(cornerRadius: DrawingConstants.imageRadius,
+                        RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                          style: .continuous)
                     )
                     .frame(width: DrawingConstants.imageWidth,
                            height: DrawingConstants.imageHeight)
                 }
             }
-            .padding(.trailing)
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: CronicaDesign.Spacing.xxs) {
                 Text(episode.itemTitle)
                     .lineLimit(DrawingConstants.lineLimit)
-                    .font(.callout)
+                    .font(CronicaDesign.Typography.caption())
                 Text("E\(episode.itemEpisodeNumberDisplay)")
-                    .font(.caption)
+                    .font(CronicaDesign.Typography.caption())
                     .foregroundColor(.secondary)
                     .lineLimit(1)
             }
             Spacer()
         }
-        .padding(.horizontal)
+        .padding(.horizontal, CronicaDesign.Spacing.sm)
         .accessibilityElement(children: .combine)
         .task {
             isWatched = persistence.isEpisodeSaved(show: show, season: season, episode: episode.id)
@@ -73,7 +72,6 @@ struct EpisodeRow: View {
 }
 
 private struct DrawingConstants {
-    static let imageRadius: CGFloat = 12
     static let imageWidth: CGFloat = 70
     static let imageHeight: CGFloat = 45
     static let lineLimit: Int = 1

--- a/AppleWatch/Views/Components/WatchlistSectionView.swift
+++ b/AppleWatch/Views/Components/WatchlistSectionView.swift
@@ -20,10 +20,13 @@ struct WatchlistSectionView: View {
                 }
             } header: {
                 Text(NSLocalizedString(title, comment: ""))
+                    .font(CronicaDesign.Typography.caption())
+                    .textCase(.uppercase)
+                    .foregroundStyle(.secondary)
             }
         } else {
             ContentUnavailableView("No results", systemImage: "rectangle.on.rectangle")
-                .padding()
+                .padding(CronicaDesign.Spacing.md)
         }
     }
 }

--- a/AppleWatch/Views/Components/WatchlistSelectorView.swift
+++ b/AppleWatch/Views/Components/WatchlistSelectorView.swift
@@ -20,60 +20,75 @@ struct WatchlistSelectorView: View {
     @Binding var sortOrder: WatchlistSortOrder
     var body: some View {
         NavigationStack {
-            Form {
-                List {
+            List {
+                Section {
+                    ForEach(SmartFiltersTypes.allCases) { list in
+                        Button {
+                            selectedCustomList = nil
+                            selectedList = list
+                            showView = false
+                        } label: {
+                            HStack(spacing: CronicaDesign.Spacing.xs) {
+                                if selectedList == list {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(SettingsStore.shared.appTheme.color)
+                                }
+                                Text(list.title)
+                                    .font(CronicaDesign.Typography.caption())
+                            }
+                        }
+                    }
+                } header: {
+                    Text("Smart List Filters")
+                        .font(CronicaDesign.Typography.caption())
+                        .textCase(.uppercase)
+                        .foregroundStyle(.secondary)
+                }
+
+                if !lists.isEmpty {
                     Section {
-                        ForEach(SmartFiltersTypes.allCases) { list in
+                        ForEach(lists) { list in
                             Button {
-                                selectedCustomList = nil
-                                selectedList = list
+                                selectedList = nil
+                                selectedCustomList = list
                                 showView = false
                             } label: {
-                                HStack {
-                                    if selectedList == list {
-                                        Image(systemName: "checkmark.circle")
+                                HStack(spacing: CronicaDesign.Spacing.xs) {
+                                    if selectedCustomList == list {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .foregroundStyle(SettingsStore.shared.appTheme.color)
                                     }
-                                    Text(list.title)
+                                    Text(list.itemTitle)
+                                        .font(CronicaDesign.Typography.caption())
                                 }
                             }
                         }
                     } header: {
-                        Text("Smart List Filters")
-                    }
-                    
-                    if !lists.isEmpty {
-                        Section {
-                            ForEach(lists) { list in
-                                Button {
-                                    selectedList = nil
-                                    selectedCustomList = list
-                                    showView = false
-                                } label: {
-                                    HStack {
-                                        if selectedCustomList == list {
-                                            Image(systemName: "checkmark.circle")
-                                        }
-                                        Text(list.itemTitle)
-                                    }
-                                }
-                            }
-                        } header: {
-                            Text("Your Lists")
-                        }
-                    }
-                    
-                    Section("Sort Order") {
-                        Picker(selection: $sortOrder) {
-                            ForEach(WatchlistSortOrder.allCases) { item in
-                                Text(item.localizableName).tag(item)
-                            }
-                        } label: {
-                            EmptyView()
-                        }
-                        .pickerStyle(.inline)
+                        Text("Your Lists")
+                            .font(CronicaDesign.Typography.caption())
+                            .textCase(.uppercase)
+                            .foregroundStyle(.secondary)
                     }
                 }
+
+                Section {
+                    Picker(selection: $sortOrder) {
+                        ForEach(WatchlistSortOrder.allCases) { item in
+                            Text(item.localizableName).tag(item)
+                        }
+                    } label: {
+                        EmptyView()
+                    }
+                    .pickerStyle(.inline)
+                } header: {
+                    Text("Sort Order")
+                        .font(CronicaDesign.Typography.caption())
+                        .textCase(.uppercase)
+                        .foregroundStyle(.secondary)
+                }
             }
+            .navigationTitle("Lists")
+            .navigationBarTitleDisplayMode(.inline)
         }
     }
 }

--- a/AppleWatch/Views/Lists/CustomListView.swift
+++ b/AppleWatch/Views/Lists/CustomListView.swift
@@ -40,7 +40,11 @@ struct CustomListView: View {
                         }
                     }
                 } header: {
-                    Text(list.itemTitle).lineLimit(1)
+                    Text(list.itemTitle)
+                        .font(CronicaDesign.Typography.caption())
+                        .textCase(.uppercase)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
             }
         } else {

--- a/AppleWatch/Views/Lists/UpNextListView.swift
+++ b/AppleWatch/Views/Lists/UpNextListView.swift
@@ -69,8 +69,6 @@ struct UpNextListView: View {
 private struct DrawingConstants {
     static let imageWidth: CGFloat = 70
     static let imageHeight: CGFloat = 50
-    static let imageRadius: CGFloat = 12
-    static let textLimit: Int = 1
 }
 
 #Preview {
@@ -85,7 +83,7 @@ private struct UpNextRowItemView: View {
         Button {
             askConfirmation.toggle()
         } label: {
-            HStack {
+            HStack(spacing: CronicaDesign.Spacing.sm) {
                 LazyImage(url: item.episode.itemImageMedium ?? item.backupImage) { state in
                     if let image = state.image {
                         image
@@ -105,18 +103,17 @@ private struct UpNextRowItemView: View {
                 .transition(.opacity)
                 .frame(width: DrawingConstants.imageWidth,
                        height: DrawingConstants.imageHeight)
-                .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
-                VStack(alignment: .leading) {
+                .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
+                VStack(alignment: .leading, spacing: CronicaDesign.Spacing.xxs) {
                     Text(item.showTitle)
-                        .font(.caption)
+                        .font(CronicaDesign.Typography.caption())
                         .lineLimit(2)
                     Text(String(format: NSLocalizedString("S%d, E%d", comment: ""), item.episode.itemSeasonNumber, item.episode.itemEpisodeNumber))
-                        .font(.caption)
+                        .font(CronicaDesign.Typography.caption())
                         .textCase(.uppercase)
                         .foregroundColor(.secondary)
                         .lineLimit(1)
                 }
-                .padding(.leading, 2)
                 Spacer()
             }
         }
@@ -133,6 +130,5 @@ private struct UpNextRowItemView: View {
         } message: {
             Text("Mark Episode \(item.episode.itemEpisodeNumber) from season \(item.episode.itemSeasonNumber) of \(item.showTitle) as Watched?")
         }
-        
     }
 }

--- a/AppleWatch/Views/Lists/UpcomingListView.swift
+++ b/AppleWatch/Views/Lists/UpcomingListView.swift
@@ -58,7 +58,7 @@ struct UpcomingListView: View {
     }
     
     private func itemRow(_ item: WatchlistItem) -> some View {
-        HStack {
+        HStack(spacing: CronicaDesign.Spacing.sm) {
             LazyImage(url: item.backCompatibleCardImage) { state in
                 if let image = state.image {
                     image
@@ -80,18 +80,17 @@ struct UpcomingListView: View {
             .transition(.opacity)
             .frame(width: DrawingConstants.imageWidth,
                    height: DrawingConstants.imageHeight)
-            .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
-            VStack(alignment: .leading) {
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
+            VStack(alignment: .leading, spacing: CronicaDesign.Spacing.xxs) {
                 Text(item.itemTitle)
-                    .font(.caption)
+                    .font(CronicaDesign.Typography.caption())
                     .lineLimit(2)
                 Text(item.itemGlanceInfo ?? String())
-                    .font(.caption)
+                    .font(CronicaDesign.Typography.caption())
                     .textCase(.uppercase)
                     .foregroundColor(.secondary)
                     .lineLimit(2)
             }
-            .padding(.leading, 2)
             Spacer()
         }
     }
@@ -104,6 +103,4 @@ struct UpcomingListView: View {
 private struct DrawingConstants {
     static let imageWidth: CGFloat = 70
     static let imageHeight: CGFloat = 50
-    static let imageRadius: CGFloat = 12
-    static let textLimit: Int = 1
 }

--- a/AppleWatch/Views/Navigation/EpisodeDetailsView.swift
+++ b/AppleWatch/Views/Navigation/EpisodeDetailsView.swift
@@ -14,74 +14,64 @@ struct EpisodeDetailsView: View {
     var showTitle = String()
     @Binding var isWatched: Bool
     private let persistence = PersistenceController.shared
+    @StateObject private var settings = SettingsStore.shared
     var body: some View {
         ScrollView {
-            VStack {
+            VStack(spacing: CronicaDesign.Spacing.sm) {
                 HeroImage(url: episode.itemImageMedium,
                           title: episode.itemTitle)
-                .clipShape(
-                    RoundedRectangle(cornerRadius: DrawingConstants.imageRadius,
-                                     style: .continuous)
-                )
-                .padding()
-                
-				VStack {
-					Text(showTitle)
-						.padding(.horizontal)
-						.font(.callout)
-						.fontWeight(.semibold)
-						.lineLimit(2)
-						.multilineTextAlignment(.center)
-					
-					Text(episode.itemTitle)
-						.padding(.horizontal)
-						.font(.caption)
-						.lineLimit(2)
-						.multilineTextAlignment(.center)
-						.foregroundStyle(.secondary)
-				}.padding(.horizontal)
-                   
-                
-				Text(String(format: NSLocalizedString("S%d, E%d", comment: ""), episode.itemSeasonNumber, episode.itemEpisodeNumber))
-                    .font(.caption)
+
+                VStack(spacing: CronicaDesign.Spacing.xxs) {
+                    Text(showTitle)
+                        .padding(.horizontal, CronicaDesign.Spacing.sm)
+                        .font(CronicaDesign.Typography.display())
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+
+                    Text(episode.itemTitle)
+                        .padding(.horizontal, CronicaDesign.Spacing.sm)
+                        .font(CronicaDesign.Typography.caption())
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, CronicaDesign.Spacing.xs)
+
+                Text(String(format: NSLocalizedString("S%d, E%d", comment: ""), episode.itemSeasonNumber, episode.itemEpisodeNumber))
+                    .font(CronicaDesign.Typography.caption())
                     .lineLimit(2)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(.secondary)
-                    .padding([.horizontal, .bottom])
-                
+                    .padding(.horizontal, CronicaDesign.Spacing.sm)
+                    .padding(.bottom, CronicaDesign.Spacing.xs)
+
                 WatchEpisodeButton(episode: episode, season: season, show: show, isWatched: $isWatched)
                     .buttonStyle(.borderedProminent)
-                    .tint(isWatched ? .orange : .green)
-                    .padding([.bottom, .horizontal])
+                    .tint(isWatched ? settings.appTheme.color.opacity(0.75) : settings.appTheme.color)
+                    .padding(.bottom, CronicaDesign.Spacing.xs)
+                    .padding(.horizontal, CronicaDesign.Spacing.sm)
                     .onAppear(perform: load)
-                
+
                 if let url = URL(string: "https://www.themoviedb.org/tv/\(show)/season/\(season)/episode/\(episode.itemEpisodeNumberDisplay)") {
                     ShareLink(item: url)
                         .labelStyle(.iconOnly)
-						.padding(.horizontal)
-                        .padding([.bottom, .horizontal])
+                        .padding(.horizontal, CronicaDesign.Spacing.sm)
+                        .padding(.bottom, CronicaDesign.Spacing.sm)
                 }
-                
+
                 AboutSectionView(about: episode.itemOverview)
-					.padding([.horizontal, .bottom])
-                
+                    .padding(.horizontal, CronicaDesign.Spacing.sm)
+                    .padding(.bottom, CronicaDesign.Spacing.sm)
             }
         }
         .background {
             TranslucentBackground(image: episode.itemImageMedium)
         }
     }
-    
+
     private func load() {
         isWatched = persistence.isEpisodeSaved(show: show,
                                                  season: season,
                                                  episode: episode.id)
     }
-}
-
-private struct DrawingConstants {
-    static let imageRadius: CGFloat = 12
-    static let imageWidth: CGFloat = 324
-    static let imageHeight: CGFloat = 163
-    static let lineLimit: Int = 1
 }

--- a/AppleWatch/Views/Navigation/ItemContentView.swift
+++ b/AppleWatch/Views/Navigation/ItemContentView.swift
@@ -20,22 +20,31 @@ struct ItemContentView: View {
 	@StateObject private var store = SettingsStore.shared
     @State private var showConfirmationPopup = false
     @StateObject private var settings = SettingsStore.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var appeared = false
     var body: some View {
         VStack {
             ScrollView {
                 HeroImage(url: image, title: title)
-				
+                    .opacity(appeared ? 1 : 0)
+
+                Text(title)
+                    .font(CronicaDesign.Typography.display())
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, CronicaDesign.Spacing.sm)
+                    .opacity(appeared ? 1 : 0)
+
 				if let quickInfo = viewModel.content?.itemQuickInfo {
 					Text(type.title)
-						.font(.caption)
+                        .font(CronicaDesign.Typography.caption())
 						.multilineTextAlignment(.center)
-						.padding(.horizontal)
-						.foregroundColor(.secondary)
+                        .padding(.horizontal, CronicaDesign.Spacing.sm)
+						.foregroundStyle(.secondary)
 					Text(quickInfo)
-						.font(.caption)
+                        .font(CronicaDesign.Typography.caption())
 						.multilineTextAlignment(.center)
-						.padding(.horizontal)
-						.foregroundColor(.secondary)
+                        .padding(.horizontal, CronicaDesign.Spacing.sm)
+						.foregroundStyle(.secondary)
 				}
                 
                 Button {
@@ -58,10 +67,11 @@ struct ItemContentView: View {
                         Text(viewModel.isInWatchlist ? "Remove" : "Add")
                             .lineLimit(1)
                             .padding(.top, 2)
-                            .font(.caption)
+                            .font(CronicaDesign.Typography.caption())
                     }
                 }
-                .buttonStyle(.bordered)
+                .buttonStyle(.borderedProminent)
+                .tint(viewModel.isInWatchlist ? .red.opacity(0.9) : settings.appTheme.color)
                 .controlSize(.small)
                 .disabled(viewModel.isLoading)
                 .confirmationDialog("Are You Sure?",
@@ -70,16 +80,15 @@ struct ItemContentView: View {
                     Button("Confirm") { updateWatchlist() }
                     Button("Cancel") {  showConfirmationPopup = false }
                 }
-                .padding()
+                .padding(.vertical, CronicaDesign.Spacing.xs)
                 
                 if let seasons = viewModel.content?.seasons {
                     NavigationLink("Seasons", value: seasons)
-                        .padding([.horizontal, .bottom])
+                        .padding([.horizontal, .bottom], CronicaDesign.Spacing.sm)
                 }
                 
                 HStack {
                     if viewModel.isInWatchlist {
-                        //customListButton
                         Button {
                             showMoreOptions.toggle()
                         } label: {
@@ -90,17 +99,17 @@ struct ItemContentView: View {
                         .sheet(isPresented: $showMoreOptions) {
                             VStack {
                                 ScrollView {
-                                    pinButton.padding(.bottom)
-                                    favoriteButton.padding(.bottom)
-                                    watchButton.padding(.bottom)
-                                    archiveButton.padding(.bottom)
+                                    pinButton.padding(.bottom, CronicaDesign.Spacing.xs)
+                                    favoriteButton.padding(.bottom, CronicaDesign.Spacing.xs)
+                                    watchButton.padding(.bottom, CronicaDesign.Spacing.xs)
+                                    archiveButton.padding(.bottom, CronicaDesign.Spacing.xs)
                                 }
-                                .padding(.horizontal)
+                                .padding(.horizontal, CronicaDesign.Spacing.sm)
                             }
                         }
                     }
                 }
-                .padding([.bottom, .horizontal])
+                .padding([.bottom, .horizontal], CronicaDesign.Spacing.sm)
                 
                 AboutSectionView(about: viewModel.content?.itemOverview)
                 
@@ -110,6 +119,15 @@ struct ItemContentView: View {
             }
         }
         .task { await viewModel.load(id: id, type: type) }
+        .onAppear {
+            if reduceMotion {
+                appeared = true
+            } else {
+                withAnimation(CronicaDesign.Motion.standard) {
+                    appeared = true
+                }
+            }
+        }
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
         .redacted(reason: viewModel.isLoading ? .placeholder : [])
@@ -154,19 +172,12 @@ struct ItemContentView: View {
                     .imageScale(.medium)
                 Text("Watched")
                     .padding(.top, 2)
-                    .font(.caption)
+                    .font(CronicaDesign.Typography.caption())
                     .lineLimit(1)
             }
             .padding(.vertical, 2)
         }
         .buttonStyle(.bordered)
-    }
-    
-    private var customListButton: some View {
-        Button("Add To List", systemImage: "rectangle.on.rectangle.angled") {
-            showCustomListSheet.toggle()
-        }
-        .labelStyle(.iconOnly)
     }
     
     private var favoriteButton: some View {
@@ -180,7 +191,7 @@ struct ItemContentView: View {
                     .imageScale(.medium)
                 Text("Favorite")
                     .padding(.top, 2)
-                    .font(.caption)
+                    .font(CronicaDesign.Typography.caption())
                     .lineLimit(1)
             }
             .padding(.vertical, 2)
@@ -199,7 +210,7 @@ struct ItemContentView: View {
                     .imageScale(.medium)
                 Text("Archive")
                     .padding(.top, 2)
-                    .font(.caption)
+                    .font(CronicaDesign.Typography.caption())
                     .lineLimit(1)
             }
             .padding(.vertical, 2)
@@ -218,7 +229,7 @@ struct ItemContentView: View {
                     .imageScale(.medium)
                 Text("Pin")
                     .padding(.top, 2)
-                    .font(.caption)
+                    .font(CronicaDesign.Typography.caption())
                     .lineLimit(1)
             }
             .padding(.vertical, 2)
@@ -251,11 +262,6 @@ struct ItemContentView: View {
             showCustomListSheet.toggle()
         }
     }
-}
-
-private struct DrawingConstants {
-    static let imageRadius: CGFloat = 12
-    static let lineLimit: Int = 1
 }
 
 #Preview {

--- a/AppleWatch/Views/Navigation/SearchView.swift
+++ b/AppleWatch/Views/Navigation/SearchView.swift
@@ -14,19 +14,22 @@ struct TrendingView: View {
     @State private var isLoaded = false
     var body: some View {
         NavigationStack {
-            Form {
+            List {
                 Section {
-                    List {
-                        ForEach(trending) { item in
-                            NavigationLink(value: item) {
-                                ItemContentRow(item: item)
-                            }
+                    ForEach(trending) { item in
+                        NavigationLink(value: item) {
+                            ItemContentRow(item: item)
                         }
                     }
-                    .redacted(reason: isLoaded ? [] : .placeholder)
+                } header: {
+                    Text("Today")
+                        .font(CronicaDesign.Typography.caption())
+                        .textCase(.uppercase)
+                        .foregroundStyle(.secondary)
                 }
             }
-			.overlay { if !isLoaded { CronicaLoadingPopupView() } }
+            .redacted(reason: isLoaded ? [] : .placeholder)
+            .overlay { if !isLoaded { CronicaLoadingPopupView() } }
             .navigationTitle("Trending")
             .navigationBarTitleDisplayMode(.inline)
             .navigationDestination(for: ItemContent.self) { item in
@@ -38,7 +41,7 @@ struct TrendingView: View {
             .onAppear(perform: load)
         }
     }
-    
+
     private func load() {
         Task {
             if !isLoaded {

--- a/AppleWatch/Views/Navigation/WatchlistView.swift
+++ b/AppleWatch/Views/Navigation/WatchlistView.swift
@@ -19,6 +19,7 @@ struct WatchlistView: View {
     @State private var selectedCustomList: CustomList?
     @State private var query = ""
     @State private var showPicker = false
+    @StateObject private var settings = SettingsStore.shared
     var body: some View {
         NavigationStack {
             VStack {
@@ -34,25 +35,12 @@ struct WatchlistView: View {
             .navigationBarTitleDisplayMode(.inline)
             .disableAutocorrection(true)
             .toolbar {
-                ToolbarItem(placement: .bottomBar) {
-                    HStack {
-                        Spacer()
-                        Button("Sort List", systemImage: "line.3.horizontal.decrease") {
-                            withAnimation { showPicker = true }
-                        }
-                        .controlSize(.small)
-                        .imageScale(.small)
-                        .labelStyle(.iconOnly)
-                        .buttonBorderShape(.circle)
-                        .contentShape(.circle)
-                        .buttonStyle(.borderedProminent)
-                        .foregroundStyle(.white.gradient)
-                        .tint(.blue)
-                        .frame(width: 50, height: 50)
-                        .clipShape(Circle())
-                        .padding(.horizontal)
-                        .shadow(radius: 2.5)
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Sort List", systemImage: "line.3.horizontal.decrease") {
+                        withAnimation { showPicker = true }
                     }
+                    .labelStyle(.iconOnly)
+                    .tint(settings.appTheme.color)
                 }
             }
             .navigationDestination(for: WatchlistItem.self) { item in

--- a/Shared/View/Components/HeroImage.swift
+++ b/Shared/View/Components/HeroImage.swift
@@ -50,12 +50,13 @@ struct HeroImage: View {
         }
         .transition(.opacity)
 #if os(watchOS)
-        .frame(height: 90)
+        .frame(height: 100)
         .clipShape(
-            RoundedRectangle(cornerRadius: 8,
+            RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                              style: .continuous)
         )
-        .padding()
+        .padding(.horizontal, CronicaDesign.Spacing.sm)
+        .padding(.vertical, CronicaDesign.Spacing.xs)
 #endif
     }
 }

--- a/Shared/View/Components/TitleView.swift
+++ b/Shared/View/Components/TitleView.swift
@@ -33,9 +33,15 @@ struct TitleView: View {
             }
             Spacer(minLength: 0)
         }
+#if os(watchOS)
+        .padding(.horizontal, CronicaDesign.Spacing.xs)
+        .padding(.top, CronicaDesign.Spacing.xxs)
+        .padding(.bottom, CronicaDesign.Spacing.xxs)
+#else
         .padding(.horizontal, CronicaDesign.Spacing.md)
         .padding(.top, CronicaDesign.Spacing.sm)
         .padding(.bottom, CronicaDesign.Spacing.xxs)
+#endif
         .accessibilityElement(children: .combine)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bring Cronica’s cinematic redesign to Apple Watch.

**Superseded by https://github.com/eggerco/cronica/pull/56** — that PR merges this Watch work plus the remaining Shared/Widget token cleanup. Prefer merging #56; this PR can be closed afterward.

## Changes (included in #56)
- Sidebar brand mark (“Cronica”) with app theme tint; global `.tint` from settings
- Watchlist toolbar sort control uses theme tint
- Detail / episode / list screens use `CronicaDesign` tokens
- Shared `HeroImage` / `TitleView` watchOS padding and media radius
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

