### PR TITLE
Finish redesign: Watch + full CronicaDesign token cleanup

### DIFF
--- a/Cronica.xcodeproj/project.pbxproj
+++ b/Cronica.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		B8C0D5017734A00600RED001 /* HomeBrandHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C0D5017734A00400RED001 /* HomeBrandHeader.swift */; };
 		B8C0D5017734A00200RED001 /* CronicaDesign.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C0D5017734A00100RED001 /* CronicaDesign.swift */; };
 		B8C0D5017734A00300RED001 /* CronicaDesign.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C0D5017734A00100RED001 /* CronicaDesign.swift */; };
+		B8C0D5017734A00700RED001 /* CronicaDesign.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C0D5017734A00100RED001 /* CronicaDesign.swift */; };
 		B84043E7289B417500D5CEBF /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF4DBE27FA511A00C7DE9F /* TitleView.swift */; };
 		B8409D1B2A81C6240048840F /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8409D1A2A81C6240048840F /* SearchView.swift */; };
 		B8409D1D2A8286130048840F /* IconGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8409D1C2A8286130048840F /* IconGridView.swift */; };
@@ -1931,6 +1932,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B8C0D5017734A00700RED001 /* CronicaDesign.swift in Sources */,
 				B824E44A2A05A9AF00E385CE /* AttributionView.swift in Sources */,
 				B84457C9297341B5009CB21F /* WatchProviders.swift in Sources */,
 				B8105257298DC0AD00723E94 /* Locale-Extensions.swift in Sources */,

--- a/Cronica.xcodeproj/project.pbxproj
+++ b/Cronica.xcodeproj/project.pbxproj
@@ -2009,7 +2009,7 @@
 				CODE_SIGN_ENTITLEMENTS = "AppleWatch/Configuration/Cronica Watch App.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"AppleWatch/Preview Content\"";
 				DEVELOPMENT_TEAM = S5A7774228;
 				ENABLE_PREVIEWS = YES;
@@ -2023,7 +2023,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.8;
+				MARKETING_VERSION = 2.7.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story.watchkitapp;
 				PRODUCT_NAME = Cronica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2045,7 +2045,7 @@
 				CODE_SIGN_ENTITLEMENTS = "AppleWatch/Configuration/Cronica Watch App.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "\"AppleWatch/Preview Content\"";
 				DEVELOPMENT_TEAM = S5A7774228;
 				ENABLE_PREVIEWS = YES;
@@ -2059,7 +2059,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.7.8;
+				MARKETING_VERSION = 2.7.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story.watchkitapp;
 				PRODUCT_NAME = Cronica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2219,7 +2219,7 @@
 				CODE_SIGN_ENTITLEMENTS = Shared/Configuration/Cronica.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = S5A7774228;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
@@ -2238,7 +2238,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 2.7.8;
+				MARKETING_VERSION = 2.7.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story;
 				PRODUCT_NAME = Cronica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2268,7 +2268,7 @@
 				CODE_SIGN_ENTITLEMENTS = Shared/Configuration/Cronica.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = S5A7774228;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				ENABLE_PREVIEWS = YES;
@@ -2287,7 +2287,7 @@
 					"@executable_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
-				MARKETING_VERSION = 2.7.8;
+				MARKETING_VERSION = 2.7.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story;
 				PRODUCT_NAME = Cronica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2313,20 +2313,20 @@
 				CODE_SIGN_ENTITLEMENTS = CronicaWidget/Configuration/CronicaWidgetExtension.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = S5A7774228;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = CronicaWidget/Configuration/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = CronicaWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.7.8;
+				MARKETING_VERSION = 2.7.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -2349,20 +2349,20 @@
 				CODE_SIGN_ENTITLEMENTS = CronicaWidget/Configuration/CronicaWidgetExtension.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = S5A7774228;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = CronicaWidget/Configuration/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = CronicaWidget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.7.8;
+				MARKETING_VERSION = 2.7.9;
 				PRODUCT_BUNDLE_IDENTIFIER = dev.alexandremadeira.Story.Widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/CronicaWidget/Views/ItemContentList.swift
+++ b/CronicaWidget/Views/ItemContentList.swift
@@ -31,8 +31,8 @@ struct ItemContentList: View {
                     PosterImage(item: item)
                         .frame(width: DrawingConstants.imageWidth,
                                height: DrawingConstants.imageHeight)
-                        .shadow(color: .black.opacity(CronicaDesign.Shadow.mediaOpacity), radius: CronicaDesign.Shadow.mediaRadius, x: 0, y: CronicaDesign.Shadow.mediaY)
                         .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
+                        .shadow(color: .black.opacity(CronicaDesign.Shadow.mediaOpacity), radius: CronicaDesign.Shadow.mediaRadius, x: 0, y: CronicaDesign.Shadow.mediaY)
                         .padding(.leading, item.id == items.first?.id ? 0 : 6)
                 }
             }

--- a/CronicaWidget/Views/ItemContentList.swift
+++ b/CronicaWidget/Views/ItemContentList.swift
@@ -31,8 +31,8 @@ struct ItemContentList: View {
                     PosterImage(item: item)
                         .frame(width: DrawingConstants.imageWidth,
                                height: DrawingConstants.imageHeight)
-                        .shadow(radius: 1)
-                        .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
+                        .shadow(color: .black.opacity(CronicaDesign.Shadow.mediaOpacity), radius: CronicaDesign.Shadow.mediaRadius, x: 0, y: CronicaDesign.Shadow.mediaY)
+                        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                         .padding(.leading, item.id == items.first?.id ? 0 : 6)
                 }
             }
@@ -42,7 +42,7 @@ struct ItemContentList: View {
                     PosterImage(item: item)
                         .frame(width: DrawingConstants.smallImageWidth,
                                height: DrawingConstants.smallImageHeight)
-                        .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
+                        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                         .padding(.leading, item.id == items.first?.id ? 0 : 4)
                 }
             }
@@ -101,5 +101,4 @@ private struct DrawingConstants {
     static let imageHeight: CGFloat = 130
     static let smallImageWidth: CGFloat = 68
     static let smallImageHeight: CGFloat = 110
-    static let imageRadius: CGFloat = 6
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Cronica
 </h1>
 
 <p align="center">
-    Cronica is a minimalist watchlist app that reminds you about upcoming releases.
+    Cronica is a cinematic watchlist for movies and TV — with reminders when something new drops.
 </p>
 
 <p align="center">
@@ -40,11 +40,14 @@ Contribute to the localization efforts of our open-source project by assisting i
 
 ##  Build information
 
-#### This project targets iOS 17, iPadOS 17, watchOS 10,  macOS 14, tvOS 17, visionOS 1 and requires Xcode 15.
+#### This project targets iOS 17, iPadOS 17, watchOS 10, macOS 14, tvOS 17, visionOS 1 and requires Xcode 15+.
+
+Current shipping version in the Xcode project: **2.7.9**.
 
 To get started you'll need to:
 
-- Get an API key to use TMDb API, you can get yours at their [website](https://www.themoviedb.org/documentation/api),  after that, go to Shared/Configuration/Key and replace the value of *tmdbApi* with your own key.
+- Get an API key to use TMDb API, you can get yours at their [website](https://www.themoviedb.org/documentation/api), after that, go to `Shared/Configuration/Key.swift` and replace the value of `tmdbApi` with your own key. Leave Aptabase empty unless you want analytics.
+- Open `Cronica.xcodeproj` in Xcode, select a simulator or device, and run the Cronica scheme.
 
 ## App Store
 

--- a/Shared/Configuration/CronicaApp.swift
+++ b/Shared/Configuration/CronicaApp.swift
@@ -111,7 +111,7 @@ struct CronicaApp: App {
 #else
                     .presentationDetents([.large])
                     .presentationDragIndicator(.visible)
-                    .presentationCornerRadius(12)
+                    .presentationCornerRadius(CronicaDesign.Radius.media)
                     .appTheme()
                     .appTint()
 #endif

--- a/Shared/Model/WatchProviders.swift
+++ b/Shared/Model/WatchProviders.swift
@@ -178,7 +178,7 @@ extension WatchProviderContent {
         providerId ?? 100
     }
     var providerImage: URL? {
-        return NetworkService.urlBuilder(size: .original, path: logoPath)
+        return NetworkService.urlBuilder(size: .medium, path: logoPath)
     }
     var listPriority: Int {
         return displayPriority ?? 10

--- a/Shared/View/Components/CronicaLoadingPopupView.swift
+++ b/Shared/View/Components/CronicaLoadingPopupView.swift
@@ -19,9 +19,9 @@ struct CronicaLoadingPopupView: View {
                     .padding()
             }
             .background(.regularMaterial)
-            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.large, style: .continuous))
             .overlay(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                RoundedRectangle(cornerRadius: CronicaDesign.Radius.large, style: .continuous)
                     .stroke(Color.black.opacity(0.2), lineWidth: 0.3)
             )
 #if os(watchOS)

--- a/Shared/View/Components/DetailedReleaseDateView.swift
+++ b/Shared/View/Components/DetailedReleaseDateView.swift
@@ -53,7 +53,7 @@ struct DetailedReleaseDateView: View {
         }
         .presentationDetents([.medium])
         .presentationDragIndicator(.visible)
-        .presentationCornerRadius(12)
+        .presentationCornerRadius(CronicaDesign.Radius.media)
         .appTheme()
         .appTint()
     }

--- a/Shared/View/ItemContent/ItemContentDetails.swift
+++ b/Shared/View/ItemContent/ItemContentDetails.swift
@@ -651,7 +651,7 @@ struct ItemContentDetails: View {
         }
         
         .frame(width: DrawingConstants.posterWidth, height: DrawingConstants.posterHeight)
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
         .onTapGesture(count: 2) {
             animate(for: store.gesture)
             viewModel.update(store.gesture)

--- a/Shared/View/Keywords/TrendingKeywordsListView.swift
+++ b/Shared/View/Keywords/TrendingKeywordsListView.swift
@@ -142,7 +142,7 @@ private struct TrendingCardView: View {
                 .frame(width: DrawingConstants.width, height: DrawingConstants.height, alignment: .center)
             }
             .frame(width: DrawingConstants.width, height: DrawingConstants.height, alignment: .center)
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
             .shadow(color: .black.opacity(0.2), radius: 2.5, x: 0, y: 2.5)
             .buttonStyle(.plain)
         }

--- a/Shared/View/Lists/Components/ListFilterView.swift
+++ b/Shared/View/Lists/Components/ListFilterView.swift
@@ -79,7 +79,6 @@ struct ListFilterView: View {
 #if !os(tvOS)
         .presentationDragIndicator(.visible)
         .presentationCornerRadius(CronicaDesign.Radius.media)
-        .presentationDragIndicator(.visible)
         .appTint()
         .appTheme()
 #endif

--- a/Shared/View/Lists/Components/ListFilterView.swift
+++ b/Shared/View/Lists/Components/ListFilterView.swift
@@ -78,7 +78,7 @@ struct ListFilterView: View {
         }
 #if !os(tvOS)
         .presentationDragIndicator(.visible)
-        .presentationCornerRadius(12)
+        .presentationCornerRadius(CronicaDesign.Radius.media)
         .presentationDragIndicator(.visible)
         .appTint()
         .appTheme()

--- a/Shared/View/Lists/EditCustomListItemSelector.swift
+++ b/Shared/View/Lists/EditCustomListItemSelector.swift
@@ -43,13 +43,13 @@ struct EditCustomListItemSelector: View {
                                         }
                                     }
                                     .frame(width: 70, height: 50)
-                                    .cornerRadius(8)
+                                    .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                                     .overlay {
                                         if itemsToRemove.contains(item) {
                                             ZStack {
                                                 Rectangle().fill(.black.opacity(0.4))
                                             }
-                                            .cornerRadius(8)
+                                            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                                         }
                                     }
                                     VStack(alignment: .leading) {
@@ -87,13 +87,13 @@ struct EditCustomListItemSelector: View {
                                     }
                                 }
                                 .frame(width: 70, height: 50)
-                                .cornerRadius(8)
+                                .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                                 .overlay {
                                     if itemsToRemove.contains(item) {
                                         ZStack {
                                             Rectangle().fill(.black.opacity(0.4))
                                         }
-                                        .cornerRadius(8)
+                                        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                                     }
                                 }
                                 VStack(alignment: .leading) {

--- a/Shared/View/Lists/ItemContentCustomListSelector.swift
+++ b/Shared/View/Lists/ItemContentCustomListSelector.swift
@@ -46,7 +46,7 @@ struct ItemContentCustomListSelector: View {
                                     }
                                 }
                                 .frame(width: 150, height: 220)
-                                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
                                 .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 10)
                             }
                             .frame(maxWidth: .infinity)
@@ -151,7 +151,7 @@ struct ItemContentCustomListSelector: View {
 #endif
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
-        .presentationCornerRadius(12)
+        .presentationCornerRadius(CronicaDesign.Radius.media)
     }
     
     private func load() {

--- a/Shared/View/Lists/NewListItemSelectorRow.swift
+++ b/Shared/View/Lists/NewListItemSelectorRow.swift
@@ -42,13 +42,13 @@ struct NewListItemSelectorRow: View {
                     }
                 }
                 .frame(width: 70, height: 50)
-                .cornerRadius(8)
+                .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                 .overlay {
                     if isSelected {
                         ZStack {
                             Rectangle().fill(.black.opacity(0.4))
                         }
-                        .cornerRadius(8)
+                        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                     }
                 }
                 .padding(.trailing, 4)

--- a/Shared/View/Lists/SelectListView.swift
+++ b/Shared/View/Lists/SelectListView.swift
@@ -74,7 +74,7 @@ struct SelectListView: View {
         .appTheme()
         .presentationDetents([lists.count > 4 ? .large : .medium])
         .presentationDragIndicator(.visible)
-        .presentationCornerRadius(12)
+        .presentationCornerRadius(CronicaDesign.Radius.media)
 #endif
     }
     

--- a/Shared/View/MenuBar/UpNextMenuBar.swift
+++ b/Shared/View/MenuBar/UpNextMenuBar.swift
@@ -79,7 +79,7 @@ struct UpNextMenuBar: View {
             }
             .transition(.opacity)
             .frame(width: 95, height: 50)
-            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
             VStack(alignment: .leading) {
                 Text(item.showTitle)
                     .font(.callout)

--- a/Shared/View/Modifiers/ConfirmationPopupModifier.swift
+++ b/Shared/View/Modifiers/ConfirmationPopupModifier.swift
@@ -34,7 +34,7 @@ struct ConfirmationPopupModifier: ViewModifier {
 #if !os(watchOS)
                     .background { Rectangle().fill(.thickMaterial) }
 #endif
-                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.large, style: .continuous))
                     .shadow(radius: 1)
                     .padding(.bottom)
                     .animation(.snappy, value: isShowing)

--- a/Shared/View/Modifiers/ItemContentContextMenu.swift
+++ b/Shared/View/Modifiers/ItemContentContextMenu.swift
@@ -199,7 +199,7 @@ struct ItemContentContextMenu: ViewModifier {
 		case .markFavorite: favoriteButton.tint(isFavorite ? .orange : .purple)
 		case .markPin: pinButton.tint(isPin ? .gray : .teal)
 		case .markArchive: archiveButton.tint(isArchive ? .gray : .indigo)
-		case .delete: watchlistButton.tint(isInWatchlist ? .red :  .blue)
+		case .delete: watchlistButton.tint(isInWatchlist ? .red : settings.appTheme.color)
 		case .share: shareButton
 		}
 	}
@@ -211,7 +211,7 @@ struct ItemContentContextMenu: ViewModifier {
 		case .markFavorite: favoriteButton.tint(isFavorite ? .orange : .purple)
 		case .markPin: pinButton.tint(isPin ? .gray : .teal)
 		case .markArchive: archiveButton.tint(isArchive ? .gray : .indigo)
-		case .delete: watchlistButton.tint(isInWatchlist ? .red :  .blue)
+		case .delete: watchlistButton.tint(isInWatchlist ? .red : settings.appTheme.color)
 		case .share: shareButton
 		}
 	}
@@ -223,7 +223,7 @@ struct ItemContentContextMenu: ViewModifier {
 		case .markFavorite: favoriteButton.tint(isFavorite ? .orange : .purple)
 		case .markPin: pinButton.tint(isPin ? .gray : .teal)
 		case .markArchive: archiveButton.tint(isArchive ? .gray : .indigo)
-		case .delete: watchlistButton.tint(isInWatchlist ? .red :  .blue)
+		case .delete: watchlistButton.tint(isInWatchlist ? .red : settings.appTheme.color)
 		case .share: shareButton
 		}
 	}
@@ -235,7 +235,7 @@ struct ItemContentContextMenu: ViewModifier {
 		case .markFavorite: favoriteButton.tint(isFavorite ? .orange : .purple)
 		case .markPin: pinButton.tint(isPin ? .gray : .teal)
 		case .markArchive: archiveButton.tint(isArchive ? .gray : .indigo)
-		case .delete: watchlistButton.tint(isInWatchlist ? .red :  .blue)
+		case .delete: watchlistButton.tint(isInWatchlist ? .red : settings.appTheme.color)
 		case .share: shareButton
 		}
 	}

--- a/Shared/View/Navigation/ExploreView.swift
+++ b/Shared/View/Navigation/ExploreView.swift
@@ -175,7 +175,7 @@ struct ExploreView: View {
             }
             .presentationDetents([.medium])
             .presentationDragIndicator(.visible)
-            .presentationCornerRadius(12)
+            .presentationCornerRadius(CronicaDesign.Radius.media)
             .unredacted()
 #if os(iOS)
             .appTint()

--- a/Shared/View/Navigation/HomeView.swift
+++ b/Shared/View/Navigation/HomeView.swift
@@ -1,6 +1,6 @@
 //
 //  HomeView.swift
-//  Story
+//  Cronica
 //
 //  Created by Alexandre Madeira on 10/02/22.
 //
@@ -39,6 +39,11 @@ struct HomeView: View {
                     compactCopy: compactHomeBrandCopy
                 )
                 .padding(.bottom, CronicaDesign.Spacing.xs)
+#endif
+#if !os(watchOS)
+                if !Key.hasTMDbKey {
+                    missingApiKeyBanner
+                }
 #endif
 #if os(iOS)
                 if showReviewBanner { CallToReviewAppView(showView: $showReviewBanner).unredacted() }
@@ -236,6 +241,23 @@ struct HomeView: View {
         false
 #endif
     }
+
+#if !os(watchOS)
+    private var missingApiKeyBanner: some View {
+        VStack(alignment: .leading, spacing: CronicaDesign.Spacing.xs) {
+            Text("TMDb API key required")
+                .font(CronicaDesign.Typography.sectionTitle())
+            Text("Add your key in Shared/Configuration/Key.swift to load trending titles and details.")
+                .font(CronicaDesign.Typography.caption())
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(CronicaDesign.Spacing.md)
+        .cronicaGlassSurface()
+        .padding(.horizontal, CronicaDesign.Spacing.md)
+        .accessibilityElement(children: .combine)
+    }
+#endif
 
     private var homeFeaturedImage: URL? {
         if let episode = upNextViewModel.episodes.first {

--- a/Shared/View/Onboard/WelcomeView.swift
+++ b/Shared/View/Onboard/WelcomeView.swift
@@ -112,8 +112,12 @@ struct WelcomeView: View {
 
     private var continueButton: some View {
         Button {
-            withAnimation(CronicaDesign.Motion.gentle) {
+            if reduceMotion {
                 displayOnboard = false
+            } else {
+                withAnimation(CronicaDesign.Motion.gentle) {
+                    displayOnboard = false
+                }
             }
         } label: {
             Text("Continue")

--- a/Shared/View/Person/CastListView.swift
+++ b/Shared/View/Person/CastListView.swift
@@ -58,11 +58,3 @@ struct CastListView: View {
 #Preview {
     CastListView(credits: Person.example)
 }
-
-private struct DrawingConstants {
-    static let profileWidth: CGFloat = 140
-    static let profileHeight: CGFloat = 200
-    static let shadowRadius: CGFloat = 2
-    static let profileRadius: CGFloat = 12
-    static let lineLimit: Int = 1
-}

--- a/Shared/View/Person/PersonCardView.swift
+++ b/Shared/View/Person/PersonCardView.swift
@@ -37,13 +37,13 @@ struct PersonCardView: View {
                         }
                         .frame(width: DrawingConstants.profileWidth,
                                height: DrawingConstants.profileHeight)
-                        .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.profileRadius,
+                        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                                     style: .continuous))
                     }
                 }
                 .frame(width: DrawingConstants.profileWidth,
                        height: DrawingConstants.profileHeight)
-                .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.profileRadius,
+                .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                             style: .continuous))
                 .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 10)
                 .overlay {
@@ -83,7 +83,7 @@ struct PersonCardView: View {
                     }
                     .frame(width: DrawingConstants.profileWidth,
                            height: DrawingConstants.profileHeight)
-                    .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.profileRadius,
+                    .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                                 style: .continuous))
                 }
                 .transition(.opacity)
@@ -174,6 +174,5 @@ private struct DrawingConstants {
     static let profileHeight: CGFloat = 200
 #endif
     static let shadowRadius: CGFloat = 2.5
-    static let profileRadius: CGFloat = 12
     static let lineLimit: Int = 1
 }

--- a/Shared/View/Person/PersonSearchImage.swift
+++ b/Shared/View/Person/PersonSearchImage.swift
@@ -53,11 +53,9 @@ private struct DrawingConstants {
 #if os(tvOS)
     static let posterWidth: CGFloat = 260
     static let posterHeight: CGFloat = 380
-    static let posterRadius: CGFloat = 12
 #else
     static let posterWidth: CGFloat = 160
     static let posterHeight: CGFloat = 240
-    static let posterRadius: CGFloat = 12
 #endif
     static let shadowRadius: CGFloat = 2.5
 }
@@ -78,7 +76,7 @@ private struct PersonSearchImageView: View {
             .transition(.opacity)
             .frame(width: DrawingConstants.posterWidth,
                    height: DrawingConstants.posterHeight)
-            .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.posterRadius,
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                         style: .continuous))
             .shadow(radius: DrawingConstants.shadowRadius)
             .padding(.zero)
@@ -99,7 +97,7 @@ private struct PersonSearchImageView: View {
         }
         .frame(width: DrawingConstants.posterWidth,
                height: DrawingConstants.posterHeight)
-        .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.posterRadius,
+        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                     style: .continuous))
         .shadow(radius: DrawingConstants.shadowRadius)
         .padding(.zero)

--- a/Shared/View/Review/ReviewView.swift
+++ b/Shared/View/Review/ReviewView.swift
@@ -48,7 +48,7 @@ struct ReviewView: View {
                                         }
                                     }
                                     .frame(width: 150, height: 220)
-                                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                    .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
                                     .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 10)
                                 }
                                 .frame(maxWidth: .infinity)
@@ -128,7 +128,7 @@ struct ReviewView: View {
         }
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
-        .presentationCornerRadius(12)
+        .presentationCornerRadius(CronicaDesign.Radius.media)
 #if os(macOS)
         .frame(width: 400, height: 400, alignment: .center)
 #elseif os(iOS)

--- a/Shared/View/Search/SearchContentPosterView.swift
+++ b/Shared/View/Search/SearchContentPosterView.swift
@@ -73,7 +73,7 @@ struct SearchContentPosterView: View {
                        height: settings.isCompactUI ? DrawingConstants.compactPosterHeight : DrawingConstants.posterHeight)
                 .clipShape(
                     RoundedRectangle(
-                        cornerRadius: settings.isCompactUI ? DrawingConstants.compactPosterRadius : DrawingConstants.posterRadius,
+                        cornerRadius: settings.isCompactUI ? CronicaDesign.Radius.compact : CronicaDesign.Radius.media,
                         style: .continuous
                     )
                 )
@@ -213,9 +213,7 @@ private struct DrawingConstants {
     static let posterWidth: CGFloat = 160
     static let posterHeight: CGFloat = 240
 #endif
-    static let posterRadius: CGFloat = 12
     static let compactPosterWidth: CGFloat = 80
-    static let compactPosterRadius: CGFloat = 4
     static let compactPosterHeight: CGFloat = 140
     static let shadowRadius: CGFloat = 2
 }

--- a/Shared/View/Season/EpisodeDetailsView.swift
+++ b/Shared/View/Season/EpisodeDetailsView.swift
@@ -57,7 +57,7 @@ struct EpisodeDetailsView: View {
                     .frame(width: (horizontalSizeClass == .regular) ? DrawingConstants.padImageWidth : DrawingConstants.imageWidth,
                            height: (horizontalSizeClass == .compact) ? DrawingConstants.imageHeight : DrawingConstants.padImageHeight)
 #endif
-                    .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
                     .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 10)
 #if os(macOS)
                     .padding(.top)
@@ -96,13 +96,13 @@ struct EpisodeDetailsView: View {
                                        isWatched: $isWatched)
                     .buttonStyle(.borderedProminent)
 #if os(iOS)
-                    .buttonBorderShape(.roundedRectangle(radius: 12))
+                    .buttonBorderShape(.roundedRectangle(radius: CronicaDesign.Radius.media))
                     .padding(isUpNext ? .leading : .horizontal)
                     .tint(settings.appTheme.color)
 #elseif os(macOS)
                     .padding(.horizontal)
                     .controlSize(.large)
-                    .tint(isWatched ? .red : .blue)
+                    .tint(isWatched ? .red : settings.appTheme.color)
 #endif
                     .keyboardShortcut("e", modifiers: [.control])
                     .shadow(radius: isUpNext ? 0 : 2.5)
@@ -166,10 +166,8 @@ private struct DrawingConstants {
     static let shadowRadius: CGFloat = 12
     static let imageWidth: CGFloat = 360
     static let imageHeight: CGFloat = 210
-    static let imageRadius: CGFloat = 12
     static let padImageWidth: CGFloat = 500
     static let padImageHeight: CGFloat = 300
-    static let padImageRadius: CGFloat = 12
 }
 
 extension EpisodeDetailsView {

--- a/Shared/View/Season/EpisodeFrameView.swift
+++ b/Shared/View/Season/EpisodeFrameView.swift
@@ -146,7 +146,7 @@ struct EpisodeFrameView: View {
                 .frame(width: DrawingConstants.imageWidth,
                        height: DrawingConstants.imageHeight)
                 .clipShape(
-                    RoundedRectangle(cornerRadius: DrawingConstants.imageRadius,
+                    RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                      style: .continuous)
                 )
                 .overlay {
@@ -157,7 +157,7 @@ struct EpisodeFrameView: View {
                                 .font(.title2)
                                 .foregroundColor(.white)
                         }
-                        .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
+                        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
                         .frame(width: DrawingConstants.imageWidth,
                                height: DrawingConstants.imageHeight)
                         .accessibilityHidden(true)
@@ -194,7 +194,7 @@ struct EpisodeFrameView: View {
             }
             .appTheme()
             .presentationDetents([.large])
-            .presentationCornerRadius(12)
+            .presentationCornerRadius(CronicaDesign.Radius.media)
             .presentationDragIndicator(.visible)
 #if os(macOS)
             .frame(minWidth: 800, idealWidth: 800, minHeight: 600, idealHeight: 600, alignment: .center)
@@ -311,6 +311,5 @@ private struct DrawingConstants {
     static let imageWidth: CGFloat = 200
     static let imageHeight: CGFloat = 120
 #endif
-    static let imageRadius: CGFloat = 12
     static let titleLineLimit: Int = 1
 }

--- a/Shared/View/Season/SeasonDetailView.swift
+++ b/Shared/View/Season/SeasonDetailView.swift
@@ -41,7 +41,7 @@ struct SeasonDetailView: View {
 #else
                             .frame(width: 338, height: 525)
 #endif
-                            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
                             .shadow(color: .black.opacity(0.2), radius: 10, x: 0, y: 10)
                         }
                         .frame(maxWidth: .infinity)
@@ -136,7 +136,7 @@ struct SeasonDetailView: View {
         }
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
-        .presentationCornerRadius(12)
+        .presentationCornerRadius(CronicaDesign.Radius.media)
 #if os(macOS)
         .frame(width: 600, height: 400)
 #endif

--- a/Shared/View/Settings/AppearanceSetting.swift
+++ b/Shared/View/Settings/AppearanceSetting.swift
@@ -142,6 +142,7 @@ struct AppearanceSetting: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(String(describing: item).capitalized))
         .accessibilityAddTraits(item == store.appTheme ? [.isButton, .isSelected] : .isButton )
         .padding(.horizontal, 4)
     }
@@ -165,6 +166,8 @@ struct AppearanceSetting: View {
                         .padding(.trailing)
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel(icon.description)
+                .accessibilityAddTraits(icons.selectedAppIcon == icon ? [.isButton, .isSelected] : .isButton)
             }
         }
         .padding(.vertical, 4)

--- a/Shared/View/Settings/AppearanceSetting.swift
+++ b/Shared/View/Settings/AppearanceSetting.swift
@@ -157,11 +157,11 @@ struct AppearanceSetting: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .overlay(
-                            RoundedRectangle(cornerRadius: 12)
+                            RoundedRectangle(cornerRadius: CronicaDesign.Radius.media)
                                 .stroke(store.appTheme.color, lineWidth: icons.selectedAppIcon == icon ? 6 : 0)
                         )
                         .frame(width: 60, height: 60)
-                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
                         .padding(.trailing)
                 }
                 .buttonStyle(.plain)

--- a/Shared/View/Settings/SettingsView.swift
+++ b/Shared/View/Settings/SettingsView.swift
@@ -32,7 +32,7 @@ struct SettingsView: View {
                 }
                 NavigationLink(value: SettingsScreens.appearance) {
                     settingsLabel(title: NSLocalizedString("Appearance", comment: ""),
-                                  icon: "paintbrush", color: .blue)
+                                  icon: "paintbrush", color: SettingsStore.shared.appTheme.color)
                 }
                 NavigationLink(value: SettingsScreens.notifications) {
                     settingsLabel(title: NSLocalizedString("Notification", comment: ""),
@@ -142,7 +142,7 @@ struct SettingsView: View {
             ZStack {
                 Rectangle()
                     .fill(color)
-                    .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                 Image(systemName: icon)
                     .foregroundColor(.white)
             }

--- a/Shared/View/Settings/WatchProviderSettings.swift
+++ b/Shared/View/Settings/WatchProviderSettings.swift
@@ -148,7 +148,7 @@ private struct WatchProviderItemSelector: View {
                 }
             }
                 .frame(width: 40, height: 40, alignment: .center)
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                 .accessibilityHidden(true)
             Text(item.providerTitle)
         }

--- a/Shared/View/Styles/TransparentGroupBox.swift
+++ b/Shared/View/Styles/TransparentGroupBox.swift
@@ -27,7 +27,7 @@ struct TransparentGroupBox: GroupBoxStyle {
             ZStack {
                 Rectangle().fill(.background)
             }
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
             .shadow(radius: 1)
         }
     }

--- a/Shared/View/Trailers/TrailerItemView.swift
+++ b/Shared/View/Trailers/TrailerItemView.swift
@@ -58,7 +58,7 @@ struct TrailerItemView: View {
                 .transition(.opacity)
                 .frame(width: DrawingConstants.imageWidth,
                        height: DrawingConstants.imageHeight)
-                .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius,
+                .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                             style: .continuous))
                 .overlay { overlay }
             }
@@ -99,7 +99,7 @@ struct TrailerItemView: View {
                     .transition(.opacity)
                     .frame(width: DrawingConstants.imageWidth,
                            height: DrawingConstants.imageHeight)
-                    .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius,
+                    .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                                 style: .continuous))
                     .overlay { overlay }
                     .applyHoverEffect()
@@ -180,7 +180,7 @@ struct TrailerItemView: View {
         .transition(.opacity)
         .frame(width: DrawingConstants.imageWidth,
                height: DrawingConstants.imageHeight)
-        .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius,
+        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                     style: .continuous))
     }
     
@@ -227,13 +227,12 @@ struct TrailerItemView: View {
         }
         .frame(width: DrawingConstants.imageWidth,
                height: DrawingConstants.imageHeight)
-        .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius,
+        .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media,
                                     style: .continuous))
     }
 }
 
 private struct DrawingConstants {
-    static let imageRadius: CGFloat = 12
     static let imageShadow: CGFloat = 2.5
 #if !os(tvOS)
     static let imageWidth: CGFloat = 220

--- a/Shared/View/Up Next/Components/VerticalUpNextCardView.swift
+++ b/Shared/View/Up Next/Components/VerticalUpNextCardView.swift
@@ -26,7 +26,7 @@ struct VerticalUpNextCardView: View {
                 selectedEpisode = item
             }
         } label: {
-            LazyImage(url: settings.preferCoverOnUpNext ? item.backupImage : item.episode.itemImageLarge ?? item.backupImage) { state in
+            LazyImage(url: settings.preferCoverOnUpNext ? item.backupImage : item.episode.itemImageMedium ?? item.backupImage) { state in
                 if let image = state.image {
                     image
                         .resizable()
@@ -45,9 +45,10 @@ struct VerticalUpNextCardView: View {
                    height: DrawingConstants.imageHeight)
             .transition(.opacity)
             .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
-            .shadow(color: .black.opacity(0.2), radius: 5, x: 0, y: 5)
+            .shadow(color: .black.opacity(CronicaDesign.Shadow.mediaOpacity), radius: CronicaDesign.Shadow.mediaRadius, x: 0, y: CronicaDesign.Shadow.mediaY)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(item.showTitle), season \(item.episode.itemSeasonNumber), episode \(item.episode.itemEpisodeNumber)")
         .contextMenu {
             Button("Show Details") {
                 selectedEpisode = item

--- a/Shared/View/Up Next/Components/VerticalUpNextCardView.swift
+++ b/Shared/View/Up Next/Components/VerticalUpNextCardView.swift
@@ -44,7 +44,7 @@ struct VerticalUpNextCardView: View {
             .frame(width: DrawingConstants.imageWidth,
                    height: DrawingConstants.imageHeight)
             .transition(.opacity)
-            .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
             .shadow(color: .black.opacity(0.2), radius: 5, x: 0, y: 5)
         }
         .buttonStyle(.plain)
@@ -79,6 +79,5 @@ private struct DrawingConstants {
     static let imageWidth: CGFloat = 280
     static let imageHeight: CGFloat = 160
 #endif
-    static let imageRadius: CGFloat = 12
     static let titleLineLimit: Int = 1
 }

--- a/Shared/View/Up Next/Components/VerticalUpNextListRowView.swift
+++ b/Shared/View/Up Next/Components/VerticalUpNextListRowView.swift
@@ -19,7 +19,7 @@ struct VerticalUpNextListRowView: View {
             askConfirmation.toggle()
         } label: {
             HStack {
-                LazyImage(url: settings.preferCoverOnUpNext ? item.backupImage : item.episode.itemImageLarge ?? item.backupImage) { state in
+                LazyImage(url: settings.preferCoverOnUpNext ? item.backupImage : item.episode.itemImageMedium ?? item.backupImage) { state in
                     if let image = state.image {
                         image
                             .resizable()
@@ -51,6 +51,7 @@ struct VerticalUpNextListRowView: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(item.showTitle), season \(item.episode.itemSeasonNumber), episode \(item.episode.itemEpisodeNumber)")
 #if !os(tvOS)
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
             Button("Watched", systemImage: "rectangle.badge.checkmark") {

--- a/Shared/View/Up Next/Components/VerticalUpNextListRowView.swift
+++ b/Shared/View/Up Next/Components/VerticalUpNextListRowView.swift
@@ -35,7 +35,7 @@ struct VerticalUpNextListRowView: View {
                 }
                 .transition(.opacity)
                 .frame(width: 80, height: 50)
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.compact, style: .continuous))
                 VStack(alignment: .leading) {
                     Text(item.showTitle)
                         .font(.callout)

--- a/Shared/View/Up Next/HorizontalUpNextListView.swift
+++ b/Shared/View/Up Next/HorizontalUpNextListView.swift
@@ -199,7 +199,7 @@ struct HorizontalUpNextListView: View {
                 .appTint()
                 .presentationDetents([.large])
                 .presentationDragIndicator(.visible)
-                .presentationCornerRadius(12)
+                .presentationCornerRadius(CronicaDesign.Radius.media)
 #if os(tvOS)
                 .ignoresSafeArea()
 #endif

--- a/Shared/View/Up Next/HorizontalUpNextListView.swift
+++ b/Shared/View/Up Next/HorizontalUpNextListView.swift
@@ -232,7 +232,7 @@ private struct UpNextCard: View {
                 }
             } label: {
                 ZStack {
-                    LazyImage(url: settings.preferCoverOnUpNext ? item.backupImage : item.episode.itemImageLarge ?? item.backupImage) { state in
+                    LazyImage(url: settings.preferCoverOnUpNext ? item.backupImage : item.episode.itemImageMedium ?? item.backupImage) { state in
                         if let image = state.image {
                             image
                                 .resizable()

--- a/Shared/View/Up Next/VerticalUpNextListView.swift
+++ b/Shared/View/Up Next/VerticalUpNextListView.swift
@@ -93,7 +93,7 @@ struct VerticalUpNextListView: View {
             .appTheme()
             .appTint()
             .presentationDragIndicator(.visible)
-            .presentationCornerRadius(12)
+            .presentationCornerRadius(CronicaDesign.Radius.media)
 #endif
         }
         .task(id: viewModel.isWatched) {
@@ -237,7 +237,6 @@ private struct DrawingConstants {
     static let imageWidth: CGFloat = 280
     static let imageHeight: CGFloat = 160
 #endif
-    static let imageRadius: CGFloat = 12
     static let titleLineLimit: Int = 1
     static let imageShadow: CGFloat = 2.5
 }

--- a/Shared/View/WatchProviders/WatchProvidersList.swift
+++ b/Shared/View/WatchProviders/WatchProvidersList.swift
@@ -116,10 +116,10 @@ struct WatchProvidersList: View {
             .frame(width: DrawingConstants.imageWidth,
                    height: DrawingConstants.imageHeight)
 #if !os(tvOS)
-            .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.imageRadius, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
 #else
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
 #endif
             .shadow(radius: 2)
 #if !os(tvOS)
@@ -139,7 +139,6 @@ struct WatchProvidersList: View {
 }
 
 private struct DrawingConstants {
-    static let imageRadius: CGFloat = 12
 #if !os(tvOS)
     static let imageWidth: CGFloat = 60
     static let imageHeight: CGFloat = 60

--- a/Shared/View/WatchlistItem/UpcomingWatchlist.swift
+++ b/Shared/View/WatchlistItem/UpcomingWatchlist.swift
@@ -284,7 +284,7 @@ private struct UpComingCardImageView: View {
 #endif
             .frame(width: settings.isCompactUI ? DrawingConstants.compactCardWidth : DrawingConstants.cardWidth,
                    height: settings.isCompactUI ? DrawingConstants.compactCardHeight : DrawingConstants.cardHeight)
-            .clipShape(RoundedRectangle(cornerRadius: DrawingConstants.cardRadius, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
             .shadow(radius: DrawingConstants.shadowRadius)
             .transition(.opacity)
             .applyHoverEffect()
@@ -303,7 +303,6 @@ private struct DrawingConstants {
     static let cardWidth: CGFloat = 280
     static let cardHeight: CGFloat = 160
 #endif
-    static let cardRadius: CGFloat = 12
     static let shadowRadius: CGFloat = 2.5
     static let lineLimits: Int = 1
     static let compactCardWidth: CGFloat = 160

--- a/Shared/ViewModel/HomeViewModel.swift
+++ b/Shared/ViewModel/HomeViewModel.swift
@@ -14,18 +14,8 @@ class HomeViewModel: ObservableObject {
     @Published var trending = [ItemContent]()
     @Published var sections = [ItemContentSection]()
     @Published var isLoaded = false
-   
-    
-    // new feature test
-    @Published var nextYearMovies: [[ItemContent]:YearEndpoint]?
-    @Published var yearMovies = [ItemContent]()
-    
-    func fetchYearMovies() async {
-        let year = try? await service.fetchYearContent(year: "2024", type: .movie)
-        guard let year else { return }
-        yearMovies.append(contentsOf: year)
-    }
-    
+
+
     /// Loads data for the home screen asynchronously, including trending items, sections, and recommendations.
     func load() async {
         if trending.isEmpty {
@@ -44,20 +34,14 @@ class HomeViewModel: ObservableObject {
         await MainActor.run {
             withAnimation { self.isLoaded = true }
         }
-        
-        if yearMovies.isEmpty {
-            await fetchYearMovies()
-        }
     }
     
     func reload() {
         withAnimation {
             isLoaded = false
-            //isLoadingRecommendations = true
         }
         trending.removeAll()
         sections.removeAll()
-       // recommendations.removeAll()
         Task { await load() }
     }
     
@@ -93,9 +77,3 @@ class HomeViewModel: ObservableObject {
 /// Theses keywords are used in some NSFW titles, this should be only used
 /// for avoiding displaying such titles in recommendations lists, explore and search.
 let nsfwKeywords = [155477, 230416, 190370, 158254, 159551, 301766]
-
-
-struct YearEndpoint: Identifiable, Hashable, Codable {
-    let id: UUID
-    let year: String
-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Final redesign ship: token cleanup on latest `main`, plus run-ready polish so you can open Xcode and go.

## Included
- **CronicaDesign everywhere left** — seasons/episodes, person, trailers, watch providers, Up Next, settings, sheets, menu bar, widgets
- **watchOS already on main** via #55; this branch was rebased so it only adds remaining Shared/Widget work
- **Faster images** — Up Next uses medium stills; provider logos use `w300` instead of original
- **Dead Home year fetch removed** (hardcoded 2024, unused UI)
- **Widget** — shadow applied after clip; `CronicaDesign` in Widget target
- **UX** — missing TMDb key banner on Home; Appearance accent/icon a11y; Welcome respects Reduce Motion
- **Version** — **2.7.9** (build 3) across app / Watch / Widget; Widget iOS deploy target aligned to 17.0

## Before you run
1. Put your TMDb key in `Shared/Configuration/Key.swift` (`tmdbApi`)
2. Open `Cronica.xcodeproj` → scheme **Cronica** → Run

## Notes
Screenshots in `Screenshots/` are still pre-redesign marketing assets; refresh later if you want App Store/README visuals updated. Trakt remains deferred.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

