### PR TITLE
Filters and light content polish

### DIFF
--- a/Shared/View/Components/CronicaDesign.swift
+++ b/Shared/View/Components/CronicaDesign.swift
@@ -158,4 +158,72 @@ extension View {
         )
 #endif
     }
+
+    /// Shared presentation chrome for filter / picker sheets.
+    func cronicaFilterSheet() -> some View {
+#if os(tvOS)
+        self
+#else
+        self
+            .presentationDragIndicator(.visible)
+            .presentationCornerRadius(CronicaDesign.Radius.large)
+            .presentationBackground(.ultraThinMaterial)
+#endif
+    }
+}
+
+// MARK: - Filter chrome (Apple TV–inspired)
+
+struct CronicaFilterSectionTitle: View {
+    let title: String
+    var body: some View {
+        Text(title)
+            .font(CronicaDesign.Typography.sectionTitle())
+            .foregroundStyle(.primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, CronicaDesign.Spacing.md)
+            .padding(.top, CronicaDesign.Spacing.sm)
+            .padding(.bottom, CronicaDesign.Spacing.xxs)
+            .accessibilityAddTraits(.isHeader)
+    }
+}
+
+struct CronicaFilterChip: View {
+    let title: String
+    let isSelected: Bool
+    var action: () -> Void
+    @StateObject private var settings = SettingsStore.shared
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(CronicaDesign.Typography.caption())
+                .fontWeight(isSelected ? .semibold : .medium)
+                .foregroundStyle(isSelected ? .white : .primary)
+                .padding(.horizontal, CronicaDesign.Spacing.sm)
+                .padding(.vertical, CronicaDesign.Spacing.xs)
+                .background {
+                    RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous)
+                        .fill(isSelected ? settings.appTheme.color : Color.secondary.opacity(0.16))
+                }
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+}
+
+struct CronicaFilterToggleRow: View {
+    let title: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        Toggle(isOn: $isOn) {
+            Text(title)
+                .font(CronicaDesign.Typography.body())
+        }
+        .padding(.horizontal, CronicaDesign.Spacing.md)
+        .padding(.vertical, CronicaDesign.Spacing.sm)
+        .cronicaGlassSurface()
+        .padding(.horizontal, CronicaDesign.Spacing.md)
+    }
 }

--- a/Shared/View/Keywords/TrendingKeywordsListView.swift
+++ b/Shared/View/Keywords/TrendingKeywordsListView.swift
@@ -63,11 +63,11 @@ struct TrendingKeywordsListView: View {
 #if !os(tvOS)
             HStack {
                 Text("Browse by Themes")
-                    .font(.title3)
-                    .fontWeight(.medium)
-                    .padding(.horizontal)
+                    .font(CronicaDesign.Typography.sectionTitle())
+                    .padding(.horizontal, CronicaDesign.Spacing.md)
                 Spacer()
             }
+            .padding(.top, CronicaDesign.Spacing.xs)
 #endif
         }
     }
@@ -129,7 +129,7 @@ private struct TrendingCardView: View {
                         HStack {
                             Text(keyword.name)
                                 .foregroundColor(.white)
-                                .font(.subheadline)
+                                .font(CronicaDesign.Typography.sectionSubtitle())
                                 .fontWeight(.semibold)
                                 .multilineTextAlignment(.leading)
                                 .lineLimit(3)
@@ -143,7 +143,12 @@ private struct TrendingCardView: View {
             }
             .frame(width: DrawingConstants.width, height: DrawingConstants.height, alignment: .center)
             .clipShape(RoundedRectangle(cornerRadius: CronicaDesign.Radius.media, style: .continuous))
-            .shadow(color: .black.opacity(0.2), radius: 2.5, x: 0, y: 2.5)
+            .shadow(
+                color: .black.opacity(CronicaDesign.Shadow.mediaOpacity),
+                radius: CronicaDesign.Shadow.mediaRadius,
+                x: 0,
+                y: CronicaDesign.Shadow.mediaY
+            )
             .buttonStyle(.plain)
         }
 #if os(iOS)
@@ -159,16 +164,16 @@ private struct TrendingCardView: View {
 
 private struct DrawingConstants {
 #if os(iOS)
-    static let columns = [GridItem(.adaptive(minimum: UIDevice.isIPad ? 240 : 160))]
-    static let width: CGFloat = UIDevice.isIPad ? 240 : 160
-    static let height: CGFloat = UIDevice.isIPad ? 140 : 100
+    static let columns = [GridItem(.adaptive(minimum: UIDevice.isIPad ? 260 : 180))]
+    static let width: CGFloat = UIDevice.isIPad ? 260 : 180
+    static let height: CGFloat = UIDevice.isIPad ? 150 : 110
 #elseif os(tvOS)
     static let columns = [GridItem(.adaptive(minimum: 400))]
     static let width: CGFloat = 400
     static let height: CGFloat = 240
 #else
-    static let columns = [GridItem(.adaptive(minimum: 240))]
-    static let width: CGFloat = 240
-    static let height: CGFloat = 140
+    static let columns = [GridItem(.adaptive(minimum: 260))]
+    static let width: CGFloat = 260
+    static let height: CGFloat = 150
 #endif
 }

--- a/Shared/View/Lists/Components/ListFilterView.swift
+++ b/Shared/View/Lists/Components/ListFilterView.swift
@@ -1,6 +1,6 @@
 //
 //  ListFilterView.swift
-//  Story (iOS)
+//  Cronica
 //
 //  Created by Alexandre Madeira on 05/02/24.
 //
@@ -13,46 +13,84 @@ struct ListFilterView: View {
     @Binding var filter: SmartFiltersTypes
     @Binding var mediaFilter: MediaTypeFilters
     @Binding var showAllItems: Bool
+
     var body: some View {
         NavigationStack {
-            Form {
-                Section {
-                    Toggle("Show All", isOn: $showAllItems)
-                    
-                    Picker("Media Type", selection: $mediaFilter) {
-                        ForEach(MediaTypeFilters.allCases) { sort in
-                            Text(sort.localizableTitle).tag(sort)
+            ScrollView {
+                VStack(alignment: .leading, spacing: CronicaDesign.Spacing.lg) {
+                    VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+                        CronicaFilterSectionTitle(title: String(localized: "Library"))
+                        CronicaFilterToggleRow(title: String(localized: "Show All"), isOn: $showAllItems)
+
+                        CronicaFilterSectionTitle(title: String(localized: "Media Type"))
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: CronicaDesign.Spacing.xs) {
+                                ForEach(MediaTypeFilters.allCases) { type in
+                                    CronicaFilterChip(
+                                        title: type.localizableTitle,
+                                        isSelected: mediaFilter == type
+                                    ) {
+                                        withAnimation(CronicaDesign.Motion.standard) {
+                                            mediaFilter = type
+                                        }
+                                    }
+                                    .disabled(!showAllItems && type != .showAll)
+                                    .opacity((!showAllItems && type != .showAll) ? 0.45 : 1)
+                                }
+                            }
+                            .padding(.horizontal, CronicaDesign.Spacing.md)
                         }
                     }
-                    .disabled(!showAllItems)
-                } header: {
-                    Text("Basic Filter")
-                }
-                
-                Picker("Sort Order",
-                       selection: $sortOrder) {
-                    ForEach(WatchlistSortOrder.allCases) { item in
-                        Text(item.localizableName).tag(item)
-                    }
-                }
-                
-                Section {
-                    Picker(selection: $filter) {
-                        ForEach(SmartFiltersTypes.allCases) { sort in
-                            Text(sort.title).tag(sort)
+
+                    VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+                        CronicaFilterSectionTitle(title: String(localized: "Sort Order"))
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: CronicaDesign.Spacing.xs) {
+                                ForEach(WatchlistSortOrder.allCases) { item in
+                                    CronicaFilterChip(
+                                        title: item.localizableName,
+                                        isSelected: sortOrder == item
+                                    ) {
+                                        withAnimation(CronicaDesign.Motion.standard) {
+                                            sortOrder = item
+                                        }
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, CronicaDesign.Spacing.md)
                         }
-                    } label: {
-                        EmptyView()
                     }
-                    .disabled(showAllItems)
-                    .pickerStyle(.inline)
-                } header: {
-                    Text("Smart Filters")
-                } footer: {
-                    if showAllItems {
-                        Text("Smart Filters only works when 'Show All Items' is disabled.")
+
+                    VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+                        CronicaFilterSectionTitle(title: String(localized: "Smart Filters"))
+                        LazyVGrid(
+                            columns: [GridItem(.adaptive(minimum: 140), spacing: CronicaDesign.Spacing.xs)],
+                            spacing: CronicaDesign.Spacing.xs
+                        ) {
+                            ForEach(SmartFiltersTypes.allCases) { item in
+                                CronicaFilterChip(
+                                    title: item.title,
+                                    isSelected: filter == item
+                                ) {
+                                    withAnimation(CronicaDesign.Motion.standard) {
+                                        filter = item
+                                    }
+                                }
+                                .disabled(showAllItems)
+                                .opacity(showAllItems ? 0.45 : 1)
+                            }
+                        }
+                        .padding(.horizontal, CronicaDesign.Spacing.md)
+
+                        if showAllItems {
+                            Text("Smart Filters only works when 'Show All Items' is disabled.")
+                                .font(CronicaDesign.Typography.caption())
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, CronicaDesign.Spacing.md)
+                        }
                     }
                 }
+                .padding(.bottom, CronicaDesign.Spacing.xl)
             }
             .navigationTitle("Filters")
 #if !os(tvOS) && !os(macOS)
@@ -61,24 +99,25 @@ struct ListFilterView: View {
             .toolbar {
 #if !os(macOS)
                 ToolbarItem(placement: .topBarLeading) {
-                    RoundedCloseButton { showView = false  }
+                    RoundedCloseButton { showView = false }
+                }
+#else
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { showView = false }
                 }
 #endif
             }
             .scrollBounceBehavior(.basedOnSize)
-            .onChange(of: filter) {
-                showView = false
-            }
-            .onChange(of: sortOrder) {
-                showView = false
-            }
-            .onChange(of: showAllItems) {
-                showView = false
+            .onChange(of: filter) { _, _ in showView = false }
+            .onChange(of: sortOrder) { _, _ in showView = false }
+            .onChange(of: showAllItems) { _, _ in showView = false }
+            .onChange(of: mediaFilter) { _, _ in
+                if showAllItems { showView = false }
             }
         }
 #if !os(tvOS)
-        .presentationDragIndicator(.visible)
-        .presentationCornerRadius(CronicaDesign.Radius.media)
+        .cronicaFilterSheet()
+        .presentationDetents([.medium, .large])
         .appTint()
         .appTheme()
 #endif

--- a/Shared/View/Lists/ItemContentCustomListSelector.swift
+++ b/Shared/View/Lists/ItemContentCustomListSelector.swift
@@ -150,8 +150,7 @@ struct ItemContentCustomListSelector: View {
         .frame(width: 500, height: 600, alignment: .center)
 #endif
         .presentationDetents([.large])
-        .presentationDragIndicator(.visible)
-        .presentationCornerRadius(CronicaDesign.Radius.media)
+        .cronicaFilterSheet()
     }
     
     private func load() {

--- a/Shared/View/Lists/SelectListView.swift
+++ b/Shared/View/Lists/SelectListView.swift
@@ -73,8 +73,7 @@ struct SelectListView: View {
         .appTint()
         .appTheme()
         .presentationDetents([lists.count > 4 ? .large : .medium])
-        .presentationDragIndicator(.visible)
-        .presentationCornerRadius(CronicaDesign.Radius.media)
+        .cronicaFilterSheet()
 #endif
     }
     

--- a/Shared/View/Navigation/ExploreView.swift
+++ b/Shared/View/Navigation/ExploreView.swift
@@ -116,38 +116,56 @@ struct ExploreView: View {
         }
         .sheet(isPresented: $showFilters) {
             NavigationStack {
-                Form {
-                    Section {
-                        Toggle("Hide Added Items", isOn: $hideAddedItems)
-                    }
-                    
-                    Section {
-                        Picker(selection: $selectedMedia) {
-                            ForEach(MediaType.allCases) { type in
-                                if type != .person {
-                                    Text(type.title).tag(type)
+                ScrollView {
+                    VStack(alignment: .leading, spacing: CronicaDesign.Spacing.lg) {
+                        VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+                            CronicaFilterSectionTitle(title: String(localized: "Options"))
+                            CronicaFilterToggleRow(title: String(localized: "Hide Added Items"), isOn: $hideAddedItems)
+                        }
+
+                        VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+                            CronicaFilterSectionTitle(title: String(localized: "Media"))
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: CronicaDesign.Spacing.xs) {
+                                    ForEach(MediaType.allCases) { type in
+                                        if type != .person {
+                                            CronicaFilterChip(
+                                                title: type.title,
+                                                isSelected: selectedMedia == type
+                                            ) {
+                                                withAnimation(CronicaDesign.Motion.standard) {
+                                                    selectedMedia = type
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                .padding(.horizontal, CronicaDesign.Spacing.md)
+                            }
+                        }
+
+                        VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
+                            CronicaFilterSectionTitle(title: String(localized: "Genres"))
+                            let genres = selectedMedia == .movie ? movies : shows
+                            LazyVGrid(
+                                columns: [GridItem(.adaptive(minimum: 120), spacing: CronicaDesign.Spacing.xs)],
+                                spacing: CronicaDesign.Spacing.xs
+                            ) {
+                                ForEach(genres) { genre in
+                                    CronicaFilterChip(
+                                        title: genre.name ?? genre.itemTitle,
+                                        isSelected: selectedGenre == genre.id
+                                    ) {
+                                        withAnimation(CronicaDesign.Motion.standard) {
+                                            selectedGenre = genre.id
+                                        }
+                                    }
                                 }
                             }
-                        } label: {
-                            Text("Media Type Filter")
-                        }
-                        .pickerStyle(.segmented)
-                    }
-                    .listRowInsets(EdgeInsets())
-                    .listRowBackground(Color.clear)
-                    
-                    Picker("Genres", selection: $selectedGenre) {
-                        if selectedMedia == .movie {
-                            ForEach(movies) { genre in
-                                Text(genre.name!).tag(genre)
-                            }
-                        } else {
-                            ForEach(shows) { genre in
-                                Text(genre.name!).tag(genre)
-                            }
+                            .padding(.horizontal, CronicaDesign.Spacing.md)
                         }
                     }
-                    .pickerStyle(.menu)
+                    .padding(.bottom, CronicaDesign.Spacing.xl)
                 }
                 .navigationTitle("Filters")
 #if os(iOS)
@@ -169,19 +187,15 @@ struct ExploreView: View {
 #endif
                 }
                 .scrollBounceBehavior(.basedOnSize)
-#if os(macOS)
-                .formStyle(.grouped)
-#endif
             }
-            .presentationDetents([.medium])
-            .presentationDragIndicator(.visible)
-            .presentationCornerRadius(CronicaDesign.Radius.media)
+            .presentationDetents([.medium, .large])
+            .cronicaFilterSheet()
             .unredacted()
 #if os(iOS)
             .appTint()
             .appTheme()
 #elseif os(macOS)
-            .frame(width: 400, height: 400, alignment: .center)
+            .frame(width: 420, height: 520, alignment: .center)
 #endif
         }
         .overlay { if !isLoaded { CronicaLoadingPopupView() } }

--- a/Shared/View/Navigation/HomeView.swift
+++ b/Shared/View/Navigation/HomeView.swift
@@ -32,13 +32,8 @@ struct HomeView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: CronicaDesign.Spacing.sm) {
 #if !os(watchOS)
-                HomeBrandHeader(
-                    featuredImage: homeFeaturedImage,
-                    featuredTitle: homeFeaturedTitle,
-                    height: CronicaDesign.Atmosphere.homeHeroHeight,
-                    compactCopy: compactHomeBrandCopy
-                )
-                .padding(.bottom, CronicaDesign.Spacing.xs)
+                homeHero
+                    .padding(.bottom, CronicaDesign.Spacing.xs)
 #endif
 #if !os(watchOS)
                 if !Key.hasTMDbKey {
@@ -243,6 +238,35 @@ struct HomeView: View {
     }
 
 #if !os(watchOS)
+    @ViewBuilder
+    private var homeHero: some View {
+        let header = HomeBrandHeader(
+            featuredImage: homeFeaturedImage,
+            featuredTitle: homeFeaturedTitle,
+            height: CronicaDesign.Atmosphere.homeHeroHeight,
+            compactCopy: compactHomeBrandCopy
+        )
+        if let episode = upNextViewModel.episodes.first {
+            NavigationLink {
+                ItemContentDetails(
+                    title: episode.showTitle,
+                    id: episode.showID,
+                    type: .tvShow
+                )
+            } label: {
+                header
+            }
+            .buttonStyle(.plain)
+        } else if let item = viewModel.trending.first {
+            NavigationLink(value: item) {
+                header
+            }
+            .buttonStyle(.plain)
+        } else {
+            header
+        }
+    }
+
     private var missingApiKeyBanner: some View {
         VStack(alignment: .leading, spacing: CronicaDesign.Spacing.xs) {
             Text("TMDb API key required")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
A light **Apple TV–inspired** polish pass: filters feel cinematic instead of Form-heavy, and Home/Search lean a bit more content-first.

## Changes
- **Shared filter chrome** — `CronicaFilterChip`, section titles, toggle rows, `cronicaFilterSheet()` (material background + larger corner radius)
- **Discover filters** — genre/media chips instead of menu + segmented Form
- **Watchlist filters** — same chip language for media, sort, and smart filters
- **List / custom-list sheets** — shared sheet chrome
- **Home hero** — taps through to the featured Up Next show or trending title
- **Search idle** — larger theme cards + design-system typography/shadows

Intentionally *not* a full Apple TV clone—just enough to make filters and primary surfaces feel more modern and content-led.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6fe8-f46d-79b1-8cc4-ceac50797734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

